### PR TITLE
fix: prevent macOS traffic light buttons from overlapping UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -28,6 +28,7 @@ import { CloudOverlay } from './components/CloudOverlay';
 import { CloudWidget } from './components/CloudWidget';
 import type { VersionUpdateInfo, PermissionInput } from './types/session';
 import type { ResumableSession } from '../../shared/types/panels';
+import { isMac } from './utils/platformUtils';
 
 // Type for IPC response
 interface IPCResponse<T = unknown> {
@@ -382,7 +383,14 @@ function App() {
 
   return (
     <ContextMenuProvider>
-      <div className="h-screen flex overflow-hidden bg-bg-primary">
+      <div className="h-screen flex flex-col overflow-hidden bg-bg-primary">
+        {isMac() && (
+          <div
+            className="flex-shrink-0 bg-bg-primary"
+            style={{ height: 38, WebkitAppRegion: 'drag' } as React.CSSProperties}
+          />
+        )}
+        <div className="flex flex-1 min-h-0">
         <MainProcessLogger />
         <Sidebar
           onHelpClick={() => setIsHelpOpen(true)}
@@ -462,6 +470,7 @@ function App() {
             </div>
           </div>
         )}
+        </div>
       </div>
     </ContextMenuProvider>
   );

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import { ProjectSessionList, ArchivedSessions } from './ProjectSessionList';
 import { ArchiveProgress } from './ArchiveProgress';
 import { Info, Clock, Check, Edit, CircleArrowDown, AlertTriangle, GitMerge, ArrowUpDown, MoreHorizontal, PanelLeftClose, PanelLeftOpen, Settings as SettingsIcon, Plus, RefreshCw } from 'lucide-react';
 import { usePaneLogo } from '../hooks/usePaneLogo';
+import { isMac } from '../utils/platformUtils';
 import { IconButton } from './ui/Button';
 import { Modal, ModalHeader, ModalBody } from './ui/Modal';
 import { Dropdown } from './ui/Dropdown';
@@ -141,8 +142,10 @@ export function Sidebar({ onHelpClick, onAboutClick, onPromptHistoryClick, onSet
           className="bg-surface-primary text-text-primary h-full flex flex-col flex-shrink-0 border-r border-border-primary"
           style={{ width: '48px' }}
         >
-          {/* Drag handle for window */}
-          <div className="h-3 flex-shrink-0" style={{ WebkitAppRegion: 'drag' } as React.CSSProperties} />
+          {/* Drag handle for window (not needed on macOS — handled by App-level spacer) */}
+          {!isMac() && (
+            <div className="h-3 flex-shrink-0" style={{ WebkitAppRegion: 'drag' } as React.CSSProperties} />
+          )}
           {/* Logo */}
           <div className="flex items-center justify-center px-1 py-2 border-b border-border-primary">
             <img src={paneLogo} alt="Pane" className="h-6 w-6" />
@@ -244,8 +247,10 @@ export function Sidebar({ onHelpClick, onAboutClick, onPromptHistoryClick, onSet
         className="bg-surface-primary text-text-primary h-full flex flex-col relative flex-shrink-0 border-r border-border-primary"
         style={{ width: `${width}px` }}
       >
-        {/* Drag handle for window */}
-        <div className="h-3 flex-shrink-0" style={{ WebkitAppRegion: 'drag' } as React.CSSProperties} />
+        {/* Drag handle for window (not needed on macOS — handled by App-level spacer) */}
+        {!isMac() && (
+          <div className="h-3 flex-shrink-0" style={{ WebkitAppRegion: 'drag' } as React.CSSProperties} />
+        )}
         {/* Resize handle */}
         <div
           className="absolute top-0 right-0 w-1 h-full cursor-col-resize group z-10"


### PR DESCRIPTION
## Summary
On macOS, the Pane logo in the sidebar and the panel tabs in the main content area overlapped with the native close/minimize/maximize (traffic light) buttons. This adds a macOS-only 38px draggable spacer at the top of the app layout to push all content below the traffic lights.

## Changes
- **App.tsx**: Restructured layout to `flex-col` with a macOS-only 38px drag region at the top, then the existing `flex` row for sidebar + content inside
- **Sidebar.tsx**: Conditionally hide the `h-3` drag handle on macOS (both collapsed and expanded states) since the app-level spacer handles it
- Uses existing `isMac()` utility from `platformUtils.ts` — no changes on Windows/Linux

## Test plan
- [ ] On macOS: verify traffic lights no longer overlap the Pane logo or tabs
- [ ] On macOS: verify window is still draggable from the top spacer area
- [ ] On macOS: verify sidebar collapsed state also has proper spacing
- [ ] On Windows/Linux: verify no visual changes (no extra spacing at top)