### PR TITLE
feat: add terminal shortcuts — hotkey-triggered clipboard paste

### DIFF
--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { NotificationSettings } from './NotificationSettings';
 import { useNotifications } from '../hooks/useNotifications';
 import { API } from '../utils/api';
-import type { AppConfig } from '../types/config';
+import type { AppConfig, TerminalShortcut } from '../types/config';
 import { useConfigStore } from '../stores/configStore';
 import {
   Shield,
@@ -21,7 +21,11 @@ import {
   Cloud,
   Trash2,
   Copy,
-  Check
+  Check,
+  Keyboard,
+  Plus,
+  Power,
+  PowerOff
 } from 'lucide-react';
 import { Input, Textarea, Checkbox } from './ui/Input';
 import { Button } from './ui/Button';
@@ -39,9 +43,10 @@ interface IPCResponse<T = unknown> {
 interface SettingsProps {
   isOpen: boolean;
   onClose: () => void;
+  initialSection?: string;
 }
 
-export function Settings({ isOpen, onClose }: SettingsProps) {
+export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
   const [_config, setConfig] = useState<AppConfig | null>(null);
   const [verbose, setVerbose] = useState(false);
   const [anthropicApiKey, setAnthropicApiKey] = useState('');
@@ -80,6 +85,7 @@ export function Settings({ isOpen, onClose }: SettingsProps) {
   const [cloudGcpProjectId, setCloudGcpProjectId] = useState('');
   const [cloudGcpZone, setCloudGcpZone] = useState('');
   const [cloudTunnelPort, setCloudTunnelPort] = useState('8080');
+  const [terminalShortcuts, setTerminalShortcuts] = useState<TerminalShortcut[]>([]);
   const { updateSettings } = useNotifications();
   const { theme, setTheme } = useTheme();
   const { fetchConfig: refreshConfigStore } = useConfigStore();
@@ -150,6 +156,9 @@ export function Settings({ isOpen, onClose }: SettingsProps) {
         }
       }
       setPreferredShell(data.preferredShell || 'auto');
+
+      // Load terminal shortcuts
+      setTerminalShortcuts(data.terminalShortcuts ?? []);
 
       // Load cloud settings
       if (data.cloud) {
@@ -223,6 +232,7 @@ export function Settings({ isOpen, onClose }: SettingsProps) {
           enabled: analyticsEnabled
         },
         preferredShell,
+        terminalShortcuts,
         cloud: cloudApiToken ? {
           provider: cloudProvider,
           apiToken: cloudApiToken,
@@ -523,6 +533,117 @@ export function Settings({ isOpen, onClose }: SettingsProps) {
                   You can still manually run /context when needed.
                 </p>
               </SettingsSection>
+            </CollapsibleCard>
+
+            {/* Terminal Shortcuts */}
+            <CollapsibleCard
+              key={`terminal-shortcuts-${initialSection}`}
+              title="Terminal Shortcuts"
+              subtitle="Bind Ctrl+Alt+letter shortcuts to paste text snippets anywhere"
+              icon={<Keyboard className="w-5 h-5" />}
+              defaultExpanded={initialSection === 'terminal-shortcuts'}
+            >
+              <div className="space-y-4">
+                {terminalShortcuts.map((shortcut, index) => (
+                  <div key={shortcut.id} className="p-3 rounded-lg bg-surface-secondary border border-border-secondary space-y-3">
+                    <div className="flex items-center gap-3">
+                      <Input
+                        label="Label"
+                        value={shortcut.label}
+                        onChange={(e) => {
+                          const updated = [...terminalShortcuts];
+                          updated[index] = { ...updated[index], label: e.target.value };
+                          setTerminalShortcuts(updated);
+                        }}
+                        placeholder="e.g. Run tests"
+                        fullWidth
+                      />
+                      <div className="flex-shrink-0 w-24">
+                        <Input
+                          label="Key"
+                          value={shortcut.key}
+                          onChange={(e) => {
+                            const val = e.target.value.toLowerCase().replace(/[^a-z]/g, '').slice(0, 1);
+                            const updated = [...terminalShortcuts];
+                            updated[index] = { ...updated[index], key: val };
+                            setTerminalShortcuts(updated);
+                          }}
+                          placeholder="a-z"
+                          fullWidth
+                        />
+                      </div>
+                      <div className="flex-shrink-0 flex items-end gap-1 pb-0.5">
+                        <button
+                          type="button"
+                          onClick={() => {
+                            const updated = [...terminalShortcuts];
+                            updated[index] = { ...updated[index], enabled: !updated[index].enabled };
+                            setTerminalShortcuts(updated);
+                          }}
+                          className={`p-2 rounded-md transition-colors ${
+                            shortcut.enabled
+                              ? 'text-status-success hover:bg-status-success/10'
+                              : 'text-text-tertiary hover:bg-surface-hover'
+                          }`}
+                          title={shortcut.enabled ? 'Enabled — click to disable' : 'Disabled — click to enable'}
+                        >
+                          {shortcut.enabled ? <Power className="w-4 h-4" /> : <PowerOff className="w-4 h-4" />}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setTerminalShortcuts(terminalShortcuts.filter((_, i) => i !== index));
+                          }}
+                          className="p-2 rounded-md text-text-tertiary hover:text-status-error hover:bg-status-error/10 transition-colors"
+                          title="Delete shortcut"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    </div>
+                    <Textarea
+                      label="Snippet text"
+                      value={shortcut.text}
+                      onChange={(e) => {
+                        const updated = [...terminalShortcuts];
+                        updated[index] = { ...updated[index], text: e.target.value };
+                        setTerminalShortcuts(updated);
+                      }}
+                      placeholder="Text to paste when shortcut is triggered..."
+                      rows={2}
+                      fullWidth
+                    />
+                    <p className="text-xs text-text-tertiary">
+                      {shortcut.key ? `Hotkey: Ctrl/Cmd + Alt + ${shortcut.key.toUpperCase()}` : 'Set a key (a-z) to assign a hotkey'}
+                    </p>
+                  </div>
+                ))}
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    setTerminalShortcuts([
+                      ...terminalShortcuts,
+                      {
+                        id: crypto.randomUUID(),
+                        label: '',
+                        key: '',
+                        text: '',
+                        enabled: true,
+                      },
+                    ]);
+                  }}
+                >
+                  <Plus className="w-4 h-4 mr-2" />
+                  Add Shortcut
+                </Button>
+                {terminalShortcuts.length === 0 && (
+                  <p className="text-sm text-text-tertiary">
+                    No shortcuts configured. Add one to bind a Ctrl+Alt+letter hotkey that pastes text into any terminal or input field.
+                  </p>
+                )}
+              </div>
             </CollapsibleCard>
 
             {/* Cloud VM */}

--- a/frontend/src/components/ShortcutHintsOverlay.tsx
+++ b/frontend/src/components/ShortcutHintsOverlay.tsx
@@ -1,0 +1,47 @@
+import type { TerminalShortcut } from '../types/config';
+import { formatKeyDisplay } from '../utils/hotkeyUtils';
+
+interface ShortcutHintsOverlayProps {
+  isVisible: boolean;
+  shortcuts: TerminalShortcut[];
+}
+
+export function ShortcutHintsOverlay({ isVisible, shortcuts }: ShortcutHintsOverlayProps) {
+  if (!isVisible) return null;
+
+  const enabledShortcuts = shortcuts.filter((s) => s.enabled && s.key);
+  const modPrefix = formatKeyDisplay('mod+alt');
+
+  return (
+    // pointer-events-none: overlay is informational only, does not intercept clicks or keys
+    <div className="fixed inset-0 z-popover flex items-center justify-center pointer-events-none">
+      <div className="bg-bg-primary/95 backdrop-blur-md border border-border-primary rounded-xl shadow-2xl p-6 max-w-md w-full animate-fade-in">
+        <div className="text-center mb-4">
+          <h3 className="text-sm font-medium text-text-secondary">Terminal Shortcuts</h3>
+          <p className="text-xs text-text-tertiary mt-1">Release to dismiss</p>
+        </div>
+        {enabledShortcuts.length === 0 ? (
+          <div className="text-center py-4">
+            <p className="text-sm text-text-tertiary">No shortcuts configured</p>
+            <p className="text-xs text-text-tertiary mt-2">
+              Press <kbd className="text-xs font-mono bg-surface-tertiary px-1.5 py-0.5 rounded">
+                {formatKeyDisplay('mod+alt+/')}
+              </kbd> to add some
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-2">
+            {enabledShortcuts.map((s) => (
+              <div key={s.id} className="flex items-center gap-3 px-3 py-2 rounded-lg bg-surface-secondary">
+                <kbd className="text-xs font-mono bg-surface-tertiary px-2 py-1 rounded text-text-primary min-w-fit">
+                  {modPrefix} + {s.key.toUpperCase()}
+                </kbd>
+                <span className="text-sm text-text-secondary truncate">{s.label}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -22,13 +22,14 @@ interface SidebarProps {
   onSettingsClick: () => void;
   isSettingsOpen: boolean;
   onSettingsClose: () => void;
+  settingsInitialSection?: string;
   width: number;
   onResize: (e: React.MouseEvent) => void;
   collapsed?: boolean;
   onToggleCollapse?: () => void;
 }
 
-export function Sidebar({ onHelpClick, onAboutClick, onPromptHistoryClick, onSettingsClick, isSettingsOpen, onSettingsClose, width, onResize, collapsed, onToggleCollapse }: SidebarProps) {
+export function Sidebar({ onHelpClick, onAboutClick, onPromptHistoryClick, onSettingsClick, isSettingsOpen, onSettingsClose, settingsInitialSection, width, onResize, collapsed, onToggleCollapse }: SidebarProps) {
   const paneLogo = usePaneLogo();
   const [showStatusGuide, setShowStatusGuide] = useState(false);
   const [version, setVersion] = useState<string>('');
@@ -227,7 +228,7 @@ export function Sidebar({ onHelpClick, onAboutClick, onPromptHistoryClick, onSet
           </div>
         </div>
 
-        <Settings isOpen={isSettingsOpen} onClose={onSettingsClose} />
+        <Settings isOpen={isSettingsOpen} onClose={onSettingsClose} initialSection={settingsInitialSection} />
         {showCreateDialog && activeProject && (
           <CreateSessionDialog
             isOpen={showCreateDialog}
@@ -378,7 +379,7 @@ export function Sidebar({ onHelpClick, onAboutClick, onPromptHistoryClick, onSet
         </div>
     </div>
 
-      <Settings isOpen={isSettingsOpen} onClose={onSettingsClose} />
+      <Settings isOpen={isSettingsOpen} onClose={onSettingsClose} initialSection={settingsInitialSection} />
       
       {/* Status Guide Modal */}
       <Modal 

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -6,6 +6,7 @@ import type { WebLinksAddon } from '@xterm/addon-web-links';
 import { useSession } from '../../contexts/SessionContext';
 import { useTheme } from '../../contexts/ThemeContext';
 import { TerminalPanelProps } from '../../types/panelComponents';
+import { useHotkeyStore } from '../../stores/hotkeyStore';
 import { renderLog, devLog } from '../../utils/console';
 import { getTerminalTheme } from '../../utils/terminalTheme';
 import { throttle } from '../../utils/performanceUtils';
@@ -140,6 +141,16 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           if (ctrlOrMeta && e.key >= '1' && e.key <= '9') return false;
           // Ctrl+Alt+1-9: switch panel tabs
           if (ctrlOrMeta && e.altKey && e.key >= '1' && e.key <= '9') return false;
+          // Ctrl/Cmd+Alt+letter: terminal shortcuts — only release if a matching hotkey is registered
+          if (ctrlOrMeta && e.altKey && /^[a-zA-Z]$/.test(e.key)) {
+            const pressed = `mod+alt+${e.key.toLowerCase()}`;
+            const hotkeys = useHotkeyStore.getState().hotkeys;
+            for (const def of hotkeys.values()) {
+              if (def.keys === pressed) return false;
+            }
+          }
+          // Ctrl/Cmd+Alt+/: open shortcut settings
+          if (ctrlOrMeta && e.altKey && e.key === '/') return false;
           // Ctrl/Cmd+W or Ctrl/Cmd+Q: close active tab
           if (ctrlOrMeta && (e.key.toLowerCase() === 'w' || e.key.toLowerCase() === 'q')) return false;
           // Ctrl/Cmd+T: open Add Tool dropdown

--- a/frontend/src/hooks/useShortcutHintsOverlay.ts
+++ b/frontend/src/hooks/useShortcutHintsOverlay.ts
@@ -1,0 +1,69 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+const HOLD_DELAY_MS = 300;
+
+export function useShortcutHintsOverlay(): { isVisible: boolean } {
+  const [isVisible, setIsVisible] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isShowingRef = useRef(false);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (isShowingRef.current) {
+      isShowingRef.current = false;
+      setIsVisible(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const isModifierKey = (key: string) =>
+      key === 'Meta' || key === 'Control' || key === 'Alt';
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.repeat) return;
+
+      // Non-modifier key pressed — cancel/dismiss
+      if (!isModifierKey(e.key)) {
+        cancel();
+        return;
+      }
+
+      // Both ctrl/cmd AND alt must be held
+      const ctrlOrMeta = e.ctrlKey || e.metaKey;
+      if (!ctrlOrMeta || !e.altKey) return;
+
+      // Suppress when modal is open
+      if (document.querySelector('[aria-modal="true"]')) return;
+
+      // Already showing or timer pending
+      if (isShowingRef.current || timerRef.current) return;
+
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        isShowingRef.current = true;
+        setIsVisible(true);
+      }, HOLD_DELAY_MS);
+    };
+
+    const handleKeyUp = (e: KeyboardEvent) => {
+      if (isModifierKey(e.key)) cancel();
+    };
+
+    const handleBlur = () => cancel();
+
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    window.addEventListener('blur', handleBlur);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+      window.removeEventListener('blur', handleBlur);
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [cancel]);
+
+  return { isVisible };
+}

--- a/frontend/src/hooks/useTerminalShortcuts.ts
+++ b/frontend/src/hooks/useTerminalShortcuts.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef } from 'react';
+import { useConfigStore } from '../stores/configStore';
+import { useHotkeyStore } from '../stores/hotkeyStore';
+
+export function useTerminalShortcuts(): void {
+  const config = useConfigStore((s) => s.config);
+  const register = useHotkeyStore((s) => s.register);
+  const unregister = useHotkeyStore((s) => s.unregister);
+  const registeredIdsRef = useRef<string[]>([]);
+
+  useEffect(() => {
+    // Unregister previous shortcuts
+    for (const id of registeredIdsRef.current) {
+      unregister(id);
+    }
+    registeredIdsRef.current = [];
+
+    const shortcuts = config?.terminalShortcuts ?? [];
+    for (const shortcut of shortcuts) {
+      if (!shortcut.enabled) continue;
+      const hotkeyId = `terminal-shortcut-${shortcut.id}`;
+      register({
+        id: hotkeyId,
+        label: shortcut.label || `Shortcut (${shortcut.key})`,
+        keys: `mod+alt+${shortcut.key}`,
+        category: 'shortcuts',
+        action: () => {
+          window.electron?.invoke('clipboard:paste', shortcut.text);
+        },
+      });
+      registeredIdsRef.current.push(hotkeyId);
+    }
+
+    return () => {
+      for (const id of registeredIdsRef.current) {
+        unregister(id);
+      }
+      registeredIdsRef.current = [];
+    };
+  }, [config?.terminalShortcuts, register, unregister]);
+}

--- a/frontend/src/stores/hotkeyStore.ts
+++ b/frontend/src/stores/hotkeyStore.ts
@@ -38,7 +38,7 @@ export interface HotkeyDefinition {
   /** Key combination string, e.g. 'mod+p', 'mod+shift+n', 'mod+alt+ArrowLeft' */
   keys: string;
   /** Grouping for help dialog display */
-  category: 'navigation' | 'session' | 'tabs' | 'view' | 'tools' | 'debug';
+  category: 'navigation' | 'session' | 'tabs' | 'view' | 'tools' | 'debug' | 'shortcuts';
   /** The function to execute */
   action: () => void;
   /** Only register in development mode? */

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -1,3 +1,11 @@
+export interface TerminalShortcut {
+  id: string;
+  label: string;
+  key: string;
+  text: string;
+  enabled: boolean;
+}
+
 export interface CustomCommand {
   name: string;
   command: string;
@@ -52,6 +60,8 @@ export interface AppConfig {
   };
   // User-defined custom commands for the Add Tool picker
   customCommands?: CustomCommand[];
+  // Terminal shortcuts — hotkey-triggered clipboard paste snippets
+  terminalShortcuts?: TerminalShortcut[];
   // Preferred shell for terminal sessions on Windows
   preferredShell?: 'auto' | 'gitbash' | 'powershell' | 'pwsh' | 'cmd';
   // Cloud VM settings

--- a/frontend/src/utils/hotkeyUtils.ts
+++ b/frontend/src/utils/hotkeyUtils.ts
@@ -20,6 +20,7 @@ export const CATEGORY_ORDER: HotkeyDefinition['category'][] = [
   'tabs',
   'view',
   'tools',
+  'shortcuts',
   'debug',
 ];
 
@@ -29,6 +30,7 @@ export const CATEGORY_LABELS: Record<HotkeyDefinition['category'], string> = {
   tabs: 'Tabs',
   view: 'View',
   tools: 'Add Tool',
+  shortcuts: 'Shortcuts',
   debug: 'Debug',
 };
 

--- a/main/src/ipc/clipboard.ts
+++ b/main/src/ipc/clipboard.ts
@@ -1,0 +1,18 @@
+import { IpcMain, clipboard } from 'electron';
+import type { AppServices } from './types';
+
+export function registerClipboardHandlers(ipcMain: IpcMain, { getMainWindow }: AppServices): void {
+  ipcMain.handle('clipboard:paste', (_event, text: string) => {
+    try {
+      clipboard.writeText(text);
+      const win = getMainWindow();
+      if (win) {
+        win.webContents.paste();
+      }
+      return { success: true };
+    } catch (error) {
+      console.error('Failed to paste from clipboard:', error);
+      return { success: false, error: 'Failed to paste' };
+    }
+  });
+}

--- a/main/src/ipc/index.ts
+++ b/main/src/ipc/index.ts
@@ -21,6 +21,7 @@ import { registerNimbalystHandlers } from './nimbalyst';
 import { registerAnalyticsHandlers } from './analytics';
 import { registerSpotlightHandlers } from './spotlight';
 import { registerCloudHandlers } from './cloud';
+import { registerClipboardHandlers } from './clipboard';
 
 
 export function registerIpcHandlers(services: AppServices): void {
@@ -45,4 +46,5 @@ export function registerIpcHandlers(services: AppServices): void {
   registerAnalyticsHandlers(ipcMain, services);
   registerSpotlightHandlers(ipcMain, services);
   registerCloudHandlers(ipcMain, services);
+  registerClipboardHandlers(ipcMain, services);
 } 

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -57,7 +57,8 @@ export class ConfigManager extends EventEmitter {
         posthogApiKey: '', // Analytics disabled - configure your own PostHog key
         posthogHost: 'https://us.i.posthog.com'
       },
-      disableAutoContext: true // Default to disabled - users can manually run /context
+      disableAutoContext: true, // Default to disabled - users can manually run /context
+      terminalShortcuts: []
     };
   }
 

--- a/main/src/types/config.ts
+++ b/main/src/types/config.ts
@@ -1,3 +1,11 @@
+export interface TerminalShortcut {
+  id: string;
+  label: string;
+  key: string;
+  text: string;
+  enabled: boolean;
+}
+
 export interface CustomCommand {
   name: string;
   command: string;
@@ -72,6 +80,8 @@ export interface AppConfig {
   };
   // User-defined custom commands for the Add Tool picker
   customCommands?: CustomCommand[];
+  // Terminal shortcuts — hotkey-triggered clipboard paste snippets
+  terminalShortcuts?: TerminalShortcut[];
   // Preferred shell for Windows terminals
   preferredShell?: 'auto' | 'gitbash' | 'powershell' | 'pwsh' | 'cmd';
   // Cloud VM settings
@@ -144,6 +154,8 @@ export interface UpdateConfigRequest {
   };
   // User-defined custom commands for the Add Tool picker
   customCommands?: CustomCommand[];
+  // Terminal shortcuts — hotkey-triggered clipboard paste snippets
+  terminalShortcuts?: TerminalShortcut[];
   // Preferred shell for Windows terminals
   preferredShell?: 'auto' | 'gitbash' | 'powershell' | 'pwsh' | 'cmd';
   // Cloud VM settings


### PR DESCRIPTION
## Summary
Adds a "Terminal Shortcuts" feature: users define text snippets bound to `Ctrl/Cmd+Alt+<letter>` hotkeys. When triggered, the snippet text is copied to the clipboard and pasted via Electron's `webContents.paste()`. Works globally — in XTerm.js terminals, AI input areas, or any focused input.

## Work Completed
### 1. Terminal Shortcuts (2026-02-27)
- **TerminalShortcut type** added to both frontend and backend config types (`id`, `label`, `key`, `text`, `enabled`)
- **ConfigManager** defaults `terminalShortcuts: []` so existing configs are unaffected
- **Hotkey system** extended with `'shortcuts'` category — shortcuts appear in Help dialog and Command Palette
- **XTerm passthrough** — `TerminalPanel` now releases `Ctrl/Cmd+Alt+letter` keys to the DOM so the hotkey store can handle them
- **clipboard:paste IPC handler** — uses Electron's `clipboard.writeText()` + `webContents.paste()` for reliable cross-platform paste
- **useTerminalShortcuts hook** — dynamically registers/unregisters hotkeys when config changes
- **Settings UI** — full CRUD for shortcuts (add, edit label/key/text, toggle enabled, delete) in a new "Terminal Shortcuts" collapsible card

### 2. Shortcut Hints Overlay (2026-02-27)
- **Hold Ctrl/Cmd+Alt for 300ms** to show a centered overlay with all configured shortcuts as keycap-label pairs
- **ShortcutHintsOverlay component** — pointer-events-none overlay with backdrop blur, empty state message
- **useShortcutHintsOverlay hook** — keydown/keyup/blur listeners with 300ms timer, modal suppression, repeat skip
- **Ctrl+Alt+/** hotkey opens Settings dialog with Terminal Shortcuts section auto-expanded
- **Settings initialSection prop** — uses React key remount pattern to force CollapsibleCard expansion
- **TerminalPanel** releases Ctrl+Alt+/ to DOM for hotkey handling

## Build Verification
- [x] `pnpm typecheck` passes (0 errors)
- [x] `pnpm lint` passes (0 errors, only pre-existing warnings)