### PR TITLE
feat: add terminal row pill shortcuts and restore Codex menu entry

### DIFF
--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, memo, useState, useRef, useEffect, useMemo } from 'react';
-import { Plus, X, Terminal, ChevronDown, GitBranch, FileCode, MoreVertical, BarChart3, Edit2, PanelRight, FolderTree, TerminalSquare, Wrench, Play } from 'lucide-react';
+import { Plus, X, Terminal, ChevronDown, GitBranch, FileCode, MoreVertical, BarChart3, Edit2, PanelRight, FolderTree, TerminalSquare, Play } from 'lucide-react';
 import { cn } from '../../utils/cn';
 import { useHotkey } from '../../hooks/useHotkey';
 import { PanelTabBarProps, PanelCreateOptions } from '../../types/panelComponents';
@@ -443,19 +443,19 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
                   <span className="ml-2">Terminal (Claude)</span>
                 </button>
               )}
-              {/* Setup Run Script - creates intelligent dev command */}
+              {/* Terminal with Codex CLI - second option */}
               {availablePanelTypes.includes('terminal') && (
                 <button
                   ref={(el) => { dropdownItemsRef.current[refIndex++] = el; }}
                   role="menuitem"
                   className={menuItemClass}
                   onClick={() => handleAddPanel('terminal', {
-                    initialCommand: `claude --dangerously-skip-permissions "${SETUP_RUN_SCRIPT_PROMPT.replace(/\n/g, ' ')}"`,
-                    title: 'Setup Run Script'
+                    initialCommand: 'codex',
+                    title: 'Codex CLI'
                   })}
                 >
-                  <Wrench className="w-4 h-4" />
-                  <span className="ml-2">Setup Run Script</span>
+                  <Terminal className="w-4 h-4" />
+                  <span className="ml-2">Terminal (Codex)</span>
                 </button>
               )}
               {/* Saved custom commands */}


### PR DESCRIPTION
## Summary

Add right-aligned pill-button shortcuts to the collapsible terminal row header for one-click Claude, Codex, and custom command panel creation. Also restore the "Terminal (Codex)" menu entry that was removed as collateral in PR #11, and remove the redundant "Setup Run Script" from the Add Tool menu.

## Work Completed

### 1. Terminal Row Pill Shortcuts (SessionView.tsx)
- Added scrollable pill container between the TERMINAL label and resize grip
- Claude pill with MessageSquare icon creates a Claude CLI terminal
- Codex pill with Code2 icon creates a Codex CLI terminal
- Custom command pills from config with TerminalSquare icon, names truncate at 18 chars
- Horizontal scroll with hidden scrollbar when pills overflow
- Resize grip stays pinned to far right, outside the scroll container

### 2. Add Tool Menu Updates (PanelTabBar.tsx)
- Restored "Terminal (Codex)" menu entry after "Terminal (Claude)"
- Removed "Setup Run Script" entry (Play button handles this on first run)
- Removed unused `Wrench` icon import

## Build Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors)
- [x] `pnpm build:main` passes
- [x] `pnpm build:frontend` passes