### PR TITLE
fix: theme-aware dropdowns and pill shortcut tooltips

### DIFF
--- a/frontend/src/components/HomePage.tsx
+++ b/frontend/src/components/HomePage.tsx
@@ -94,9 +94,9 @@ export function HomePage() {
               }}
               className="px-3 py-1.5 rounded-md bg-surface-tertiary hover:bg-surface-hover text-sm text-text-primary border border-border-secondary focus:outline-none focus:ring-2 focus:ring-interactive cursor-pointer"
             >
-              <option value="light">Light</option>
-              <option value="dark">Dark</option>
-              <option value="oled">OLED Black</option>
+              <option value="light" className="bg-surface-tertiary text-text-primary">Light</option>
+              <option value="dark" className="bg-surface-tertiary text-text-primary">Dark</option>
+              <option value="oled" className="bg-surface-tertiary text-text-primary">OLED Black</option>
             </select>
           </div>
 
@@ -134,9 +134,9 @@ export function HomePage() {
                 onChange={(e) => handleShellChange(e.target.value)}
                 className="px-3 py-1.5 rounded-md border border-border-primary bg-surface-secondary text-text-primary text-sm focus:ring-2 focus:ring-interactive focus:border-interactive"
               >
-                <option value="auto">Auto (Git Bash)</option>
+                <option value="auto" className="bg-surface-secondary text-text-primary">Auto (Git Bash)</option>
                 {availableShells.map(shell => (
-                  <option key={shell.id} value={shell.id}>{shell.name}</option>
+                  <option key={shell.id} value={shell.id} className="bg-surface-secondary text-text-primary">{shell.name}</option>
                 ))}
               </select>
             </div>

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -16,7 +16,7 @@ import { useResizable } from '../hooks/useResizable';
 import { useResizableHeight } from '../hooks/useResizableHeight';
 import { usePanelStore } from '../stores/panelStore';
 import { panelApi } from '../services/panelApi';
-import { PanelTabBar, SETUP_RUN_SCRIPT_PROMPT } from './panels/PanelTabBar';
+import { PanelTabBar } from './panels/PanelTabBar';
 import { PanelContainer } from './panels/PanelContainer';
 import { SessionProvider } from '../contexts/SessionContext';
 import { ToolPanel, ToolPanelType, PANEL_CAPABILITIES } from '../../../shared/types/panels';
@@ -26,6 +26,8 @@ import type { Project } from '../types/project';
 import { devLog, renderLog } from '../utils/console';
 import { useConfigStore } from '../stores/configStore';
 import { cycleIndex } from '../utils/arrayUtils';
+import { formatKeyDisplay } from '../utils/hotkeyUtils';
+import { Tooltip } from './ui/Tooltip';
 
 export const SessionView = memo(() => {
   const { activeView, activeProjectId } = useNavigationStore();
@@ -277,14 +279,14 @@ export const SessionView = memo(() => {
   });
 
   useHotkey({
-    id: 'add-tool-setup-run-script',
-    label: 'Add Setup Run Script',
+    id: 'add-tool-terminal-codex',
+    label: 'Add Terminal (Codex)',
     keys: 'mod+shift+2',
     category: 'tools',
     enabled: () => isInSessionView,
     action: () => handlePanelCreate('terminal', {
-      initialCommand: `claude --dangerously-skip-permissions "${SETUP_RUN_SCRIPT_PROMPT.replace(/\n/g, ' ')}"`,
-      title: 'Setup Run Script'
+      initialCommand: 'codex',
+      title: 'Codex CLI'
     }),
   });
 
@@ -839,30 +841,32 @@ export const SessionView = memo(() => {
                   {/* Middle: scrollable pill shortcuts */}
                   <div className="flex-1 flex items-center gap-2 overflow-x-auto ml-3 scrollbar-none">
                     {/* Claude pill */}
-                    <button
-                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium text-text-tertiary border border-border-primary hover:bg-surface-hover hover:text-text-secondary transition-colors whitespace-nowrap flex-shrink-0"
-                      onClick={() => handlePanelCreate('terminal', {
-                        initialCommand: 'claude --dangerously-skip-permissions',
-                        title: 'Claude CLI'
-                      })}
-                      title="Open Claude CLI terminal"
-                    >
-                      <MessageSquare className="w-3 h-3" />
-                      Claude
-                    </button>
+                    <Tooltip content={<kbd className="px-1.5 py-0.5 text-xs font-mono bg-surface-tertiary rounded">{formatKeyDisplay('mod+shift+1')}</kbd>} side="top">
+                      <button
+                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium text-text-tertiary border border-border-primary hover:bg-surface-hover hover:text-text-secondary transition-colors whitespace-nowrap flex-shrink-0"
+                        onClick={() => handlePanelCreate('terminal', {
+                          initialCommand: 'claude --dangerously-skip-permissions',
+                          title: 'Claude CLI'
+                        })}
+                      >
+                        <MessageSquare className="w-3 h-3" />
+                        Claude
+                      </button>
+                    </Tooltip>
 
                     {/* Codex pill */}
-                    <button
-                      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium text-text-tertiary border border-border-primary hover:bg-surface-hover hover:text-text-secondary transition-colors whitespace-nowrap flex-shrink-0"
-                      onClick={() => handlePanelCreate('terminal', {
-                        initialCommand: 'codex',
-                        title: 'Codex CLI'
-                      })}
-                      title="Open Codex CLI terminal"
-                    >
-                      <Code2 className="w-3 h-3" />
-                      Codex
-                    </button>
+                    <Tooltip content={<kbd className="px-1.5 py-0.5 text-xs font-mono bg-surface-tertiary rounded">{formatKeyDisplay('mod+shift+2')}</kbd>} side="top">
+                      <button
+                        className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-medium text-text-tertiary border border-border-primary hover:bg-surface-hover hover:text-text-secondary transition-colors whitespace-nowrap flex-shrink-0"
+                        onClick={() => handlePanelCreate('terminal', {
+                          initialCommand: 'codex',
+                          title: 'Codex CLI'
+                        })}
+                      >
+                        <Code2 className="w-3 h-3" />
+                        Codex
+                      </button>
+                    </Tooltip>
 
                     {/* Custom command pills */}
                     {customCommands.map((cmd, index) => (


### PR DESCRIPTION
## Summary
- Fix select `<option>` elements on the home page rendering as white in dark mode by adding theme-aware background/text classes
- Wrap Claude and Codex terminal row pills with `<Tooltip>` component showing keyboard shortcuts (`Ctrl+Shift+1` / `Ctrl+Shift+2`) on hover
- Fix `mod+shift+2` hotkey which was mapped to a stale "Setup Run Script" action — now correctly opens Codex CLI to match its position in the Add Tool dropdown

## Test plan
- [ ] Switch to dark mode, verify theme dropdown options are no longer white
- [ ] Hover Claude pill in terminal row, verify tooltip shows `Ctrl+Shift+1` above
- [ ] Hover Codex pill in terminal row, verify tooltip shows `Ctrl+Shift+2` above
- [ ] Press `Ctrl+Shift+2`, verify it opens a Codex CLI terminal