### PR TITLE
feat: add keyboard shortcut tooltips to sidebar and panel bar buttons

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -7,6 +7,8 @@ import { Info, Check, Edit, CircleArrowDown, AlertTriangle, GitMerge, ArrowUpDow
 import { usePaneLogo } from '../hooks/usePaneLogo';
 import { isMac } from '../utils/platformUtils';
 import { IconButton } from './ui/Button';
+import { Tooltip } from './ui/Tooltip';
+import { formatKeyDisplay } from '../utils/hotkeyUtils';
 import { Modal, ModalHeader, ModalBody } from './ui/Modal';
 import { Dropdown } from './ui/Dropdown';
 import type { DropdownItem } from './ui/Dropdown';
@@ -212,18 +214,22 @@ export function Sidebar({ onHelpClick, onAboutClick, onSettingsClick, isSettings
 
           {/* Bottom actions */}
           <div className="flex-shrink-0 flex flex-col items-center gap-1 py-2 border-t border-border-primary">
-            <IconButton
-              onClick={onSettingsClick}
-              aria-label="Settings"
-              size="sm"
-              icon={<SettingsIcon className="w-4 h-4" />}
-            />
-            <IconButton
-              onClick={onToggleCollapse}
-              aria-label="Expand sidebar"
-              size="sm"
-              icon={<PanelLeftOpen className="w-4 h-4" />}
-            />
+            <Tooltip content={<kbd className="px-1.5 py-0.5 text-xs font-mono bg-surface-tertiary rounded">{formatKeyDisplay('mod+,')}</kbd>} side="right">
+              <IconButton
+                onClick={onSettingsClick}
+                aria-label="Settings"
+                size="sm"
+                icon={<SettingsIcon className="w-4 h-4" />}
+              />
+            </Tooltip>
+            <Tooltip content={<kbd className="px-1.5 py-0.5 text-xs font-mono bg-surface-tertiary rounded">{formatKeyDisplay('mod+b')}</kbd>} side="right">
+              <IconButton
+                onClick={onToggleCollapse}
+                aria-label="Expand sidebar"
+                size="sm"
+                icon={<PanelLeftOpen className="w-4 h-4" />}
+              />
+            </Tooltip>
           </div>
         </div>
 
@@ -276,12 +282,14 @@ export function Sidebar({ onHelpClick, onAboutClick, onSettingsClick, isSettings
           </div>
           <div className="flex items-center space-x-2 flex-shrink-0">
             {onToggleCollapse && (
-              <IconButton
-                onClick={onToggleCollapse}
-                aria-label="Collapse sidebar"
-                size="md"
-                icon={<PanelLeftClose className="w-5 h-5" />}
-              />
+              <Tooltip content={<kbd className="px-1.5 py-0.5 text-xs font-mono bg-surface-tertiary rounded">{formatKeyDisplay('mod+b')}</kbd>} side="bottom">
+                <IconButton
+                  onClick={onToggleCollapse}
+                  aria-label="Collapse sidebar"
+                  size="md"
+                  icon={<PanelLeftClose className="w-5 h-5" />}
+                />
+              </Tooltip>
             )}
             <IconButton
               onClick={onHelpClick}
@@ -293,18 +301,20 @@ export function Sidebar({ onHelpClick, onAboutClick, onSettingsClick, isSettings
                 </svg>
               }
             />
-            <IconButton
-              onClick={onSettingsClick}
-              aria-label="Settings"
-              data-testid="settings-button"
-              size="md"
-              icon={
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
-              }
-            />
+            <Tooltip content={<kbd className="px-1.5 py-0.5 text-xs font-mono bg-surface-tertiary rounded">{formatKeyDisplay('mod+,')}</kbd>} side="bottom">
+              <IconButton
+                onClick={onSettingsClick}
+                aria-label="Settings"
+                data-testid="settings-button"
+                size="md"
+                icon={
+                  <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+                  </svg>
+                }
+              />
+            </Tooltip>
           </div>
         </div>
 

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -482,22 +482,24 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
 
         {/* Add Panel dropdown button - outside overflow container so dropdown isn't clipped */}
         <div className="relative h-9 flex items-center ml-1 flex-shrink-0" ref={dropdownRef}>
-          <button
-            className="inline-flex items-center h-9 px-3 text-sm text-text-tertiary hover:text-text-primary hover:bg-surface-hover rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring-subtle"
-            onClick={() => setShowDropdown(!showDropdown)}
-            onKeyDown={(e) => {
-              if (e.key === 'ArrowDown' && !showDropdown) {
-                e.preventDefault();
-                setShowDropdown(true);
-              }
-            }}
-            aria-haspopup="menu"
-            aria-expanded={showDropdown}
-          >
-            <Plus className="w-4 h-4 mr-1" />
-            Add Tool
-            <ChevronDown className="w-3 h-3 ml-1" />
-          </button>
+          <Tooltip content={<kbd className="px-1.5 py-0.5 text-xs font-mono bg-surface-tertiary rounded">{formatKeyDisplay('mod+t')}</kbd>} side="bottom">
+            <button
+              className="inline-flex items-center h-9 px-3 text-sm text-text-tertiary hover:text-text-primary hover:bg-surface-hover rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus-ring-subtle"
+              onClick={() => setShowDropdown(!showDropdown)}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowDown' && !showDropdown) {
+                  e.preventDefault();
+                  setShowDropdown(true);
+                }
+              }}
+              aria-haspopup="menu"
+              aria-expanded={showDropdown}
+            >
+              <Plus className="w-4 h-4 mr-1" />
+              Add Tool
+              <ChevronDown className="w-3 h-3 ml-1" />
+            </button>
+          </Tooltip>
 
           {showDropdown && (() => {
             // Track ref index for keyboard navigation
@@ -688,18 +690,20 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
 
           {/* Detail panel toggle */}
           {onToggleDetailPanel && (
-            <button
-              onClick={onToggleDetailPanel}
-              className={cn(
-                "p-1.5 rounded transition-colors",
-                detailPanelVisible
-                  ? "text-text-primary bg-surface-hover"
-                  : "text-text-tertiary hover:text-text-primary hover:bg-surface-hover"
-              )}
-              title={detailPanelVisible ? "Hide detail panel" : "Show detail panel"}
-            >
-              <PanelRight className="w-4 h-4" />
-            </button>
+            <Tooltip content={<kbd className="px-1.5 py-0.5 text-xs font-mono bg-surface-tertiary rounded">{formatKeyDisplay('mod+shift+b')}</kbd>} side="bottom">
+              <button
+                onClick={onToggleDetailPanel}
+                className={cn(
+                  "p-1.5 rounded transition-colors",
+                  detailPanelVisible
+                    ? "text-text-primary bg-surface-hover"
+                    : "text-text-tertiary hover:text-text-primary hover:bg-surface-hover"
+                )}
+                title={detailPanelVisible ? "Hide detail panel" : "Show detail panel"}
+              >
+                <PanelRight className="w-4 h-4" />
+              </button>
+            </Tooltip>
           )}
         </div>
       </div>


### PR DESCRIPTION
## Summary
Adds keyboard shortcut tooltip indicators to all sidebar and panel bar buttons that have shortcuts but were missing visual hints.

## Changes
- **Sidebar toggle** (collapse/expand): Shows `Ctrl+B` / `⌘B` on hover
- **Settings button** (both collapsed and expanded sidebar): Shows `Ctrl+,` / `⌘,`
- **Add Tool button** in panel tab bar: Shows `Ctrl+T` / `⌘T`
- **Detail panel toggle** in panel tab bar: Shows `Ctrl+Shift+B` / `⌘⇧B`

Uses the existing `Tooltip` + `formatKeyDisplay()` pattern already established by terminal pills and panel tab shortcuts.

## Build Verification
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (0 errors)