### PR TITLE
fix: detect baseBranch for main repo sessions and fix cross-platform git quoting

### DIFF
--- a/main/src/services/worktreeManager.ts
+++ b/main/src/services/worktreeManager.ts
@@ -1049,7 +1049,7 @@ Co-Authored-By: Pane <runpane@users.noreply.github.com>` : commitMessage;
   async getLastCommits(worktreePath: string, count: number, commandRunner: CommandRunner): Promise<RawCommitData[]> {
     try {
       const { stdout } = await commandRunner.execAsync(
-        `git log -${count} --pretty=format:'%H|%s|%ai|%an' --shortstat`,
+        `git log -${count} --pretty=format:"%H|%s|%ai|%an" --shortstat`,
         worktreePath
       );
 


### PR DESCRIPTION
## Summary
- Main repo sessions (created when opening a project) were bypassing the git introspection pipeline, leaving `baseBranch` and `baseCommit` as NULL — causing "Branch: unknown" in the git menu and broken history commands
- `getOrCreateMainRepoSession()` now detects the remote tracking branch (`origin/main` or `origin/master`) and HEAD commit before creating the session, mirroring the normal session creation flow
- Migrates `file.ts` git commit commands to use the existing `buildGitCommitCommand()` from `shellEscape.ts` instead of inline Unix-only single-quote escaping
- Fixes single-quoted git log format string in `worktreeManager.ts` that broke on Windows (`cmd.exe` doesn't support single quotes)

## Test plan
- [ ] Create a new project and verify the git menu shows the correct branch (not "unknown")
- [ ] Verify git history loads without errors on the main repo session
- [ ] Test git commit via the file editor on Windows (or WSL) to verify cross-platform quoting
- [ ] Verify normal session creation (via Create Session dialog) still works correctly