### PR TITLE
feat: add option to run sessions without worktree isolation

### DIFF
--- a/main/src/ipc/session.ts
+++ b/main/src/ipc/session.ts
@@ -141,7 +141,9 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
         return { success: false, error: 'Task queue not initialized' };
       }
 
-      const count = request.count || 1;
+      // Force count to 1 for main-repo sessions — no worktree isolation means
+      // multiple panes would all operate on the same directory concurrently.
+      const count = request.isMainRepo ? 1 : (request.count || 1);
 
       const sessionToolType: 'claude' | 'none' | undefined = request.toolType;
 
@@ -157,7 +159,8 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
           sessionToolType,
           request.commitMode,
           request.commitModeSettings,
-          request.folderId
+          request.folderId,
+          request.isMainRepo
         );
 
         return { success: true, data: { jobIds: jobs.map(job => job.id) } };
@@ -168,6 +171,7 @@ export function registerSessionHandlers(ipcMain: IpcMain, services: AppServices)
           permissionMode: request.permissionMode,
           projectId: targetProject.id,
           folderId: request.folderId,
+          isMainRepo: request.isMainRepo,
           baseBranch: request.baseBranch,
           autoCommit: request.autoCommit,
           toolType: sessionToolType,

--- a/main/src/services/sessionManager.ts
+++ b/main/src/services/sessionManager.ts
@@ -51,7 +51,7 @@ import { addSessionLog, cleanupSessionLogs } from '../ipc/logs';
 import { PathResolver } from '../utils/pathResolver';
 import { CommandRunner } from '../utils/commandRunner';
 import { withLock } from '../utils/mutex';
-import { escapeShellArg } from '../utils/shellEscape';
+import { detectGitBase } from './worktreeManager';
 import * as os from 'os';
 import { panelManager } from './panelManager';
 import type { AnalyticsManager } from './analyticsManager';
@@ -482,35 +482,9 @@ export class SessionManager extends EventEmitter {
       const worktreeName = 'main'; // Use 'main' as the worktree name
       const prompt = ''; // Empty prompt - user hasn't sent anything yet
 
-      // Detect baseBranch and baseCommit from git (mirrors worktree creation pipeline)
+      // Detect baseBranch and baseCommit from git
       const { commandRunner } = this.getOrCreateContext(project);
-      let baseBranch: string | undefined;
-      let baseCommit: string | undefined;
-      try {
-        const localBranch = (await commandRunner.execAsync('git branch --show-current', project.path)).stdout.trim();
-        if (localBranch) {
-          // Only set baseBranch when a remote tracking ref exists — this is used for stale detection.
-          // For local-only repos, leave baseBranch undefined to avoid false stale indicators.
-          // Branch display falls back to `git rev-parse --abbrev-ref HEAD` at render time.
-          const remoteRef = `origin/${localBranch}`;
-          try {
-            await commandRunner.execAsync(`git rev-parse --verify ${escapeShellArg(remoteRef)}`, project.path);
-            baseBranch = remoteRef;
-          } catch {
-            // No remote tracking branch — leave baseBranch undefined
-          }
-        }
-      } catch {
-        // Leave baseBranch undefined if git commands fail
-      }
-      try {
-        // Derive baseCommit from baseBranch ref so the pair is consistent
-        // (avoids stale-state mismatch when local is ahead of remote)
-        const commitRef = baseBranch || 'HEAD';
-        baseCommit = (await commandRunner.execAsync(`git rev-parse ${escapeShellArg(commitRef)}`, project.path)).stdout.trim();
-      } catch {
-        // Leave baseCommit undefined if git commands fail
-      }
+      const { baseBranch, baseCommit } = await detectGitBase(project.path, commandRunner);
 
       const session = this.createSessionWithId(
         sessionId,

--- a/main/src/types/session.ts
+++ b/main/src/types/session.ts
@@ -66,6 +66,7 @@ export interface CreateSessionRequest {
   permissionMode?: 'approve' | 'ignore';
   projectId?: number;
   folderId?: string;
+  isMainRepo?: boolean;
   baseBranch?: string;
   autoCommit?: boolean;
   model?: string;


### PR DESCRIPTION
## Summary
- Adds a "Use worktree" toggle in the Create Session dialog's advanced options, allowing users to choose between running in an isolated git worktree (default) or directly in the project directory
- Extracts `detectGitBase()` utility and `resolveWorkingDirectory()` method into `worktreeManager` so both user-created sessions and internal `getOrCreateMainRepoSession()` share a single code path for git branch/commit detection
- Eliminates duplicated git introspection logic that was previously inline in `sessionManager.ts`

## Test plan
- [ ] Create a session with "Use worktree" enabled (default) — verify worktree is created as before
- [ ] Create a session with "Use worktree" disabled — verify session runs in project directory, no worktree created
- [ ] Create a non-worktree session with a remote branch selected — verify checkout to that branch
- [ ] Create a non-worktree session with no branch selected — verify current branch is used
- [ ] Archive a non-worktree session — verify no worktree removal is attempted
- [ ] Verify existing main repo sessions (from project scripts) still work correctly