### PR TITLE
fix: track CLI processes in resource monitor and use delta-based CPU

### DIFF
--- a/main/src/services/panels/cli/AbstractCliManager.ts
+++ b/main/src/services/panels/cli/AbstractCliManager.ts
@@ -296,6 +296,22 @@ export abstract class AbstractCliManager extends EventEmitter {
   }
 
   /**
+   * Returns a map of sessionId → array of PTY PIDs for that session.
+   * Used by resource monitoring to discover which CLI processes belong to which session.
+   */
+  getSessionPids(): Map<string, number[]> {
+    const result = new Map<string, number[]>();
+    for (const [, cliProcess] of this.processes) {
+      const pid = cliProcess.process.pid;
+      if (!pid) continue;
+      const pids = result.get(cliProcess.sessionId) || [];
+      pids.push(pid);
+      result.set(cliProcess.sessionId, pids);
+    }
+    return result;
+  }
+
+  /**
    * Check if a panel is running
    */
   isPanelRunning(panelId: string): boolean {


### PR DESCRIPTION
## Summary
- **Track CLI processes**: Resource monitor now discovers Claude Code/Codex processes via `CliToolRegistry.getAllManagers()` + new `AbstractCliManager.getSessionPids()`, not just terminal shell PTYs
- **Fix CPU measurement**: Replace lifetime-average CPU (both Windows `$_.CPU/elapsed` and Unix `ps %cpu`) with delta-based calculation using cached cumulative CPU time between polls
- **Cache management**: Auto-cleanup stale PID entries from CPU sample cache when processes exit

## Test plan
- [ ] Run `pnpm electron-dev`, open Resource Usage panel
- [ ] Start a Claude Code session, verify it appears with child processes (not just bash)
- [ ] While Claude is actively processing, verify CPU% reflects real activity (not near-zero)
- [ ] Verify memory numbers remain accurate
- [ ] Test on Windows (PowerShell path) and Linux/macOS (ps cputime path)