### PR TITLE
feat: add default terminal shortcuts for common workflows

### DIFF
--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -58,7 +58,36 @@ export class ConfigManager extends EventEmitter {
         posthogHost: 'https://us.i.posthog.com'
       },
       disableAutoContext: true, // Default to disabled - users can manually run /context
-      terminalShortcuts: []
+      terminalShortcuts: [
+        {
+          id: 'default-root-cause',
+          label: 'Root cause or symptom?',
+          key: 'e',
+          text: 'Think hard: is this the root cause or a symptom? How might we solve this at the root?',
+          enabled: true
+        },
+        {
+          id: 'default-codex-review',
+          label: 'Codex review loop',
+          key: 'r',
+          text: "Prepare a PR once done with changes, then run in a subagent 'codex review --base main' and wait for it to respond. Read its response and make the fixes it suggests. Continue in a loop until it says there are no longer any issues.",
+          enabled: true
+        },
+        {
+          id: 'default-rebase-merge-release',
+          label: 'Rebase, merge & release',
+          key: 'd',
+          text: 'Rebase main and merge the PR to main, then bump a release patch.',
+          enabled: true
+        },
+        {
+          id: 'default-review-and-release',
+          label: 'Review and release loop',
+          key: 's',
+          text: "Prepare a PR once done with changes, then run in a subagent 'codex review --base main' and wait for it to respond. Read its response and make the fixes it suggests. Continue in a loop until it says there are no longer any issues. Once there are no issues, rebase main and merge the PR to main, then bump a release patch.",
+          enabled: true
+        }
+      ]
     };
   }
 


### PR DESCRIPTION
## Summary
- Adds 4 default terminal shortcuts (Ctrl/Cmd+Alt+letter) for new installations:
  - **E** - Root cause or symptom? (prompts root cause thinking)
  - **R** - Codex review loop (PR + iterative codex review)
  - **D** - Rebase, merge & release (rebase main, merge PR, bump patch)
  - **S** - Review and release loop (full codex review + merge + release)

## Test plan
- [ ] Fresh install should show the 4 default shortcuts in Settings > Shortcuts
- [ ] Existing installations with config.json keep their current shortcuts unchanged
- [ ] Each shortcut pastes correct text when triggered