### PR TITLE
fix: make CreateSessionDialog non-blocking during branch loading

### DIFF
--- a/frontend/src/components/CreateSessionDialog.tsx
+++ b/frontend/src/components/CreateSessionDialog.tsx
@@ -67,6 +67,7 @@ export function CreateSessionDialog({
   const [isBranchDropdownOpen, setIsBranchDropdownOpen] = useState(false);
   const [highlightedBranchIndex, setHighlightedBranchIndex] = useState(0);
   const [userEditedName, setUserEditedName] = useState(false);
+  const userEditedNameRef = useRef(false);
   const branchDropdownRef = useRef<HTMLDivElement>(null);
   const branchInputRef = useRef<HTMLInputElement>(null);
   const branchListRef = useRef<HTMLDivElement>(null);
@@ -86,6 +87,7 @@ export function CreateSessionDialog({
       }
       setSessionCount(1);
       setUserEditedName(!!initialSessionName);
+      userEditedNameRef.current = !!initialSessionName;
       setFormData(prev => ({ ...prev, count: 1, baseBranch: initialBaseBranch }));
     }
   }, [isOpen, loadPreferences, initialSessionName, initialBaseBranch]);
@@ -138,7 +140,7 @@ export function CreateSessionDialog({
               if (defaultBranch) {
                 setFormData(prev => ({ ...prev, baseBranch: defaultBranch.name }));
                 // Auto-populate session name from default branch if user hasn't edited
-                if (!initialSessionName && !userEditedName) {
+                if (!initialSessionName && !userEditedNameRef.current) {
                   const baseName = defaultBranch.name.replace(/^[^/]+\//, '');
                   const existingNames = new Set(existingSessions.map(s => s.name));
                   let autoName = baseName;
@@ -642,6 +644,7 @@ export function CreateSessionDialog({
                   setSessionName(value);
                   setFormData({ ...formData, worktreeTemplate: value });
                   setUserEditedName(true);
+                  userEditedNameRef.current = true;
                   // Real-time validation
                   const error = validateWorktreeName(value);
                   setWorktreeError(error);


### PR DESCRIPTION
## Summary
- Removed the blocking skeleton that prevented the entire CreateSessionDialog form from rendering while git branches were being fetched
- The form now renders immediately with focus on the Pane Name input; only the branch selector shows a skeleton placeholder until branches load
- Users can fill in the name, toggle advanced options, and submit before branches finish loading

## Test plan
- [ ] Open the Create Pane dialog and verify the name input is focused immediately
- [ ] Verify the branch selector shows a skeleton while loading, then populates
- [ ] Verify the rest of the form (name, advanced, submit) is interactive during branch loading