### PR TITLE
fix: use e.code for Ctrl+Alt+letter shortcuts on macOS

### DIFF
--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -142,8 +142,12 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           // Ctrl+Alt+1-9: switch panel tabs
           if (ctrlOrMeta && e.altKey && e.key >= '1' && e.key <= '9') return false;
           // Ctrl/Cmd+Alt+letter: terminal shortcuts — only release if a matching hotkey is registered
-          if (ctrlOrMeta && e.altKey && /^[a-zA-Z]$/.test(e.key)) {
-            const pressed = `mod+alt+${e.key.toLowerCase()}`;
+          // Use e.code instead of e.key because macOS Option key modifies e.key to special chars
+          // (e.g. Option+A produces e.key='å' but e.code='KeyA')
+          // Skip AltGr — on Windows/Linux international layouts AltGr sets both ctrlKey+altKey
+          // but is used for character input (e.g. AltGr+Q = '@' on German keyboards)
+          if (ctrlOrMeta && e.altKey && !e.getModifierState('AltGraph') && /^Key[A-Z]$/.test(e.code)) {
+            const pressed = `mod+alt+${e.code.slice(3).toLowerCase()}`;
             const hotkeys = useHotkeyStore.getState().hotkeys;
             for (const def of hotkeys.values()) {
               if (def.keys === pressed) return false;

--- a/frontend/src/stores/hotkeyStore.ts
+++ b/frontend/src/stores/hotkeyStore.ts
@@ -73,7 +73,17 @@ function normalizeKeyEvent(e: KeyboardEvent): string {
   if (e.altKey) parts.push('alt');
   if (e.shiftKey) parts.push('shift');
   // parts is already in canonical order because we push in that order
-  let key = e.key.length === 1 ? e.key.toLowerCase() : e.key;
+  // Use e.code for letters when alt is held — macOS Option key modifies e.key
+  // (e.g. Option+A produces 'å' instead of 'a')
+  // Skip AltGr — on Windows/Linux international layouts AltGr sets both ctrlKey+altKey
+  // but is used for character input (e.g. AltGr+Q = '@' on German keyboards)
+  const isAltGr = e.getModifierState('AltGraph');
+  const altLetterMatch = e.altKey && !isAltGr && e.code.match(/^Key([A-Z])$/);
+  let key = altLetterMatch
+    ? altLetterMatch[1].toLowerCase()
+    : e.key.length === 1
+      ? e.key.toLowerCase()
+      : e.key;
   // Use e.code for digits when shift is held — e.key is layout-dependent
   // (e.g. Shift+2 produces '@' on US, '"' on UK, different on AZERTY)
   const digitMatch = e.shiftKey && e.code.match(/^Digit(\d)$/);


### PR DESCRIPTION
## Summary
- On macOS, the Option key (Alt) modifies `e.key` to produce special characters (e.g. Option+A → `å`), breaking Ctrl+Alt+letter shortcut detection
- Fixed by using `e.code` (physical key position, e.g. `KeyA`) instead of `e.key` in both the terminal key handler and the hotkey store normalizer
- Same pattern already used in the codebase for shift+digit handling

## Test plan
- [ ] Verify Ctrl+Alt+letter shortcuts still work on Windows/Linux
- [ ] Verify Ctrl+Alt+letter shortcuts now work on macOS (Ctrl+Option+letter)
- [ ] Verify Cmd+Option+letter also works on macOS
- [ ] Verify the shortcut hints overlay still appears when holding Ctrl+Alt / Cmd+Option
- [ ] Verify regular typing in the terminal is unaffected