### PR TITLE
fix: always start explorer folders collapsed

### DIFF
--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -132,7 +132,6 @@ interface FileTreeProps {
   sessionId: string;
   onFileSelect: (file: FileItem | null) => void;
   selectedPath: string | null;
-  initialExpandedDirs?: string[];
   initialSearchQuery?: string;
   initialShowSearch?: boolean;
   onTreeStateChange?: (state: { expandedDirs: string[]; searchQuery: string; showSearch: boolean }) => void;
@@ -142,14 +141,13 @@ function FileTree({
   sessionId, 
   onFileSelect, 
   selectedPath,
-  initialExpandedDirs,
   initialSearchQuery,
   initialShowSearch,
   onTreeStateChange 
 }: FileTreeProps) {
   const [files, setFiles] = useState<Map<string, FileItem[]>>(new Map());
   const [expandedDirs, setExpandedDirs] = useState<Set<string>>(
-    new Set(initialExpandedDirs || [''])
+    new Set([''])
   );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -945,7 +943,6 @@ export function FileEditor({
           sessionId={sessionId}
           onFileSelect={loadFile}
           selectedPath={selectedFile?.path || null}
-          initialExpandedDirs={initialState?.expandedDirs}
           initialSearchQuery={initialState?.searchQuery}
           initialShowSearch={initialState?.showSearch}
           onTreeStateChange={handleTreeStateChange}


### PR DESCRIPTION
## Summary
- Nested folders in the Explorer panel were restored from persisted state as "expanded" but showed no children (file data only loads for root on mount)
- Users had to collapse and re-expand to see contents
- Fix: always initialize folder expansion with only root expanded, ignoring persisted expansion state

## Test plan
- [ ] Open Explorer panel, expand a nested folder, switch away and back — folder should start collapsed
- [ ] Expanding any nested folder should correctly show its children