### PR TITLE
feat: add VS Code UX defaults to xterm.js terminal

### DIFF
--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -134,6 +134,11 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           fastScrollModifier: 'ctrl',
           fastScrollSensitivity: 5,
           scrollSensitivity: 1,
+          altClickMovesCursor: true,
+          drawBoldTextInBrightColors: true,
+          rescaleOverlappingGlyphs: true,
+          minimumContrastRatio: 1,
+          macOptionIsMeta: false,
         });
         console.log('[TerminalPanel] XTerm instance created:', !!terminal);
 


### PR DESCRIPTION
## Summary
- Add `altClickMovesCursor: true` - Alt+click jumps cursor to position
- Add `drawBoldTextInBrightColors: true` - Better readability for bold text
- Add `rescaleOverlappingGlyphs: true` - Prevents glyph rendering artifacts
- Add `minimumContrastRatio: 1` - Accessibility baseline
- Add `macOptionIsMeta: false` - Explicit macOS Option key behavior

## Test plan
- [ ] Alt+click in terminal moves cursor to clicked position
- [ ] Bold text renders in brighter colors
- [ ] No glyph rendering artifacts with special characters