### PR TITLE
fix: reduce resource monitor battery drain

### DIFF
--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -687,8 +687,12 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
             <Cpu className="w-3.5 h-3.5" />
             {snapshot && (
               <>
-                <span>{snapshot.totalCpuPercent.toFixed(0)}%</span>
-                <span className="text-text-quaternary">|</span>
+                {snapshot.cpuReady && (
+                  <>
+                    <span>{snapshot.totalCpuPercent.toFixed(0)}%</span>
+                    <span className="text-text-quaternary">|</span>
+                  </>
+                )}
                 <span>{formatMemory(snapshot.totalMemoryMB)}</span>
               </>
             )}
@@ -768,7 +772,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
         {/* Summary */}
         <div className="flex items-center gap-4 px-3 py-2 border-b border-border-secondary">
           <span className="text-sm text-text-secondary">
-            CPU <strong className="text-text-primary">{snapshot.totalCpuPercent.toFixed(1)}%</strong>
+            CPU <strong className="text-text-primary">{snapshot.cpuReady ? `${snapshot.totalCpuPercent.toFixed(1)}%` : '—'}</strong>
           </span>
           <span className="text-sm text-text-secondary">
             Memory <strong className="text-text-primary">{formatMemory(snapshot.totalMemoryMB)}</strong>
@@ -790,7 +794,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
                 <span className="text-sm font-medium text-text-primary">Pane App</span>
               </div>
               <div className="flex items-center gap-3 text-xs text-text-tertiary font-mono">
-                <span>{electronTotalCpu.toFixed(1)}%</span>
+                <span>{snapshot.cpuReady ? `${electronTotalCpu.toFixed(1)}%` : '—'}</span>
                 <span>{formatMemory(electronTotalMem)}</span>
               </div>
             </button>
@@ -798,7 +802,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
               <div key={p.pid} className="flex items-center justify-between px-3 py-1 pl-8">
                 <span className="text-xs text-text-secondary">{p.label}</span>
                 <div className="flex items-center gap-3 text-xs text-text-tertiary font-mono">
-                  <span>{p.cpuPercent.toFixed(1)}%</span>
+                  <span>{snapshot.cpuReady ? `${p.cpuPercent.toFixed(1)}%` : '—'}</span>
                   <span>{formatMemory(p.memoryMB)}</span>
                 </div>
               </div>
@@ -828,7 +832,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
                   <span className="text-sm font-medium text-text-primary truncate">{sess.sessionName}</span>
                 </div>
                 <div className="flex items-center gap-3 text-xs text-text-tertiary font-mono flex-shrink-0 ml-2">
-                  <span>{sess.totalCpuPercent.toFixed(1)}%</span>
+                  <span>{snapshot.cpuReady ? `${sess.totalCpuPercent.toFixed(1)}%` : '—'}</span>
                   <span>{formatMemory(sess.totalMemoryMB)}</span>
                 </div>
               </button>
@@ -836,7 +840,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
                 <div key={child.pid} className="flex items-center justify-between px-3 py-1 pl-8">
                   <span className="text-xs text-text-secondary truncate">{child.name}</span>
                   <div className="flex items-center gap-3 text-xs text-text-tertiary font-mono flex-shrink-0 ml-2">
-                    <span>{child.cpuPercent.toFixed(1)}%</span>
+                    <span>{snapshot.cpuReady ? `${child.cpuPercent.toFixed(1)}%` : '—'}</span>
                     <span>{formatMemory(child.memoryMB)}</span>
                   </div>
                 </div>

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -550,24 +550,28 @@ async function createWindow() {
     if (gitStatusManager) {
       gitStatusManager.handleVisibilityChange(false); // false = visible/focused
     }
+    resourceMonitorService.handleVisibilityChange(false);
   });
 
   mainWindow.on('blur', () => {
     if (gitStatusManager) {
       gitStatusManager.handleVisibilityChange(true); // true = hidden/blurred
     }
+    resourceMonitorService.handleVisibilityChange(true);
   });
 
   mainWindow.on('minimize', () => {
     if (gitStatusManager) {
       gitStatusManager.handleVisibilityChange(true); // true = hidden/minimized
     }
+    resourceMonitorService.handleVisibilityChange(true);
   });
 
   mainWindow.on('restore', () => {
     if (gitStatusManager) {
       gitStatusManager.handleVisibilityChange(false); // false = visible/restored
     }
+    resourceMonitorService.handleVisibilityChange(false);
   });
 }
 

--- a/main/src/services/resourceMonitorService.ts
+++ b/main/src/services/resourceMonitorService.ts
@@ -18,12 +18,6 @@ interface RawProcessStats {
   memoryMB: number;
 }
 
-interface ProcessStats {
-  name: string;
-  cpuPercent: number;
-  memoryMB: number;
-}
-
 interface CpuSample {
   cpuTimeSeconds: number;
   timestamp: number;
@@ -43,6 +37,8 @@ export class ResourceMonitorService extends EventEmitter {
   private isActivePolling = false;
   private pollInProgress = false;
   private previousCpuSamples = new Map<number, CpuSample>();
+  private isHidden = false;
+  private needsCpuWarmup = false;
 
   initialize(app: App): void {
     this.app = app;
@@ -314,6 +310,10 @@ export class ResourceMonitorService extends EventEmitter {
   }
 
   async getSnapshot(): Promise<ResourceSnapshot> {
+    const cpuReady = !this.needsCpuWarmup;
+    // After this poll seeds the cache, the next poll will have real deltas
+    if (this.needsCpuWarmup) this.needsCpuWarmup = false;
+
     const electronProcesses = this.getElectronMetrics();
     const sessions = await this.getSessionMetrics();
 
@@ -328,6 +328,7 @@ export class ResourceMonitorService extends EventEmitter {
 
     return {
       timestamp: Date.now(),
+      cpuReady,
       totalCpuPercent: Math.round((electronTotal.cpu + sessionTotal.cpu) * 10) / 10,
       totalMemoryMB: Math.round((electronTotal.mem + sessionTotal.mem) * 10) / 10,
       electronProcesses,
@@ -336,6 +337,7 @@ export class ResourceMonitorService extends EventEmitter {
   }
 
   startIdlePolling(): void {
+    if (this.isHidden) return;
     this.stopAllPolling();
     const poll = async (): Promise<void> => {
       if (this.pollInProgress) return;
@@ -350,10 +352,14 @@ export class ResourceMonitorService extends EventEmitter {
       }
     };
     void poll();
-    this.idleTimer = setInterval(() => void poll(), 30_000);
+    this.idleTimer = setInterval(() => void poll(), 180_000);
   }
 
   startActivePolling(): void {
+    if (this.isHidden) {
+      this.isActivePolling = true;
+      return;
+    }
     this.stopAllPolling();
     this.isActivePolling = true;
     const poll = async (): Promise<void> => {
@@ -369,13 +375,28 @@ export class ResourceMonitorService extends EventEmitter {
       }
     };
     void poll();
-    this.activeTimer = setInterval(() => void poll(), 2_000);
+    this.activeTimer = setInterval(() => void poll(), 5_000);
   }
 
   stopActivePolling(): void {
     if (this.isActivePolling) {
       this.isActivePolling = false;
       this.startIdlePolling();
+    }
+  }
+
+  handleVisibilityChange(hidden: boolean): void {
+    this.isHidden = hidden;
+    if (hidden) {
+      this.stopAllPolling();
+      this.previousCpuSamples.clear();
+      this.needsCpuWarmup = true;
+    } else {
+      if (this.isActivePolling) {
+        this.startActivePolling();
+      } else {
+        this.startIdlePolling();
+      }
     }
   }
 

--- a/shared/types/resourceMonitor.ts
+++ b/shared/types/resourceMonitor.ts
@@ -23,6 +23,7 @@ export interface SessionResourceInfo {
 
 export interface ResourceSnapshot {
   timestamp: number;
+  cpuReady: boolean;
   totalCpuPercent: number;
   totalMemoryMB: number;
   electronProcesses: ElectronProcessInfo[];


### PR DESCRIPTION
## Summary
- Stop all resource monitor polling on window blur/minimize, resume on focus/restore (matches existing gitStatusManager pattern)
- Increase idle polling interval from 30s to 3 minutes (6x reduction in process spawns)
- Increase active polling interval from 2s to 5s (2.5x reduction when popover open)
- Clear CPU sample cache on blur to prevent stale delta calculations on resume
- Add `cpuReady` flag to `ResourceSnapshot` so frontend hides CPU values until valid delta data is available (shows "—" instead of misleading 0%)
- Remove unused `ProcessStats` interface (dead code)

## Test plan
- [ ] Open Pane, verify resource chip shows CPU% and memory normally
- [ ] Alt-tab away, verify resource polling stops (check backend logs)
- [ ] Alt-tab back, verify chip shows only memory initially, then CPU appears after second poll
- [ ] Open resource popover, verify 5s refresh rate feels responsive
- [ ] Close popover, verify polling drops to 3-minute idle interval
- [ ] Minimize window, verify polling stops completely
- [ ] Restore window, verify polling resumes