### PR TITLE
fix: WSL git history broken by cmd.exe percent escaping

### DIFF
--- a/main/src/utils/commandExecutor.ts
+++ b/main/src/utils/commandExecutor.ts
@@ -1,9 +1,10 @@
-import { execSync as nodeExecSync, ExecSyncOptions, ExecSyncOptionsWithStringEncoding, ExecSyncOptionsWithBufferEncoding, exec, ExecOptions } from 'child_process';
+import { execSync as nodeExecSync, execFileSync as nodeExecFileSync, ExecSyncOptions, ExecSyncOptionsWithStringEncoding, ExecSyncOptionsWithBufferEncoding, exec, execFile, ExecOptions, ExecFileOptions } from 'child_process';
 import { promisify } from 'util';
 import { getShellPath } from './shellPath';
-import { WSLContext, wrapCommandForWSL } from './wslUtils';
+import { WSLContext, getWSLExecArgs } from './wslUtils';
 
 const nodeExecAsync = promisify(exec);
+const nodeExecFileAsync = promisify(execFile);
 
 /**
  * Extended ExecSyncOptions that includes a custom 'silent' flag
@@ -23,30 +24,56 @@ class CommandExecutor {
     const extendedOptions = options as ExtendedExecSyncOptions;
     const silentMode = extendedOptions?.silent === true;
 
-    // Handle WSL command wrapping
-    let actualCommand = command;
-    let actualOptions = extendedOptions;
-
-    if (wslContext) {
-      // Extract cwd for WSL (it's a Linux path)
-      const wslCwd = typeof cwd === 'string' ? cwd : undefined;
-      actualCommand = wrapCommandForWSL(command, wslContext.distribution, wslCwd);
-      // WSL handles cwd internally, remove it from options
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { cwd: _cwd, silent: _silent, ...cleanOptions } = extendedOptions || {};
-      actualOptions = cleanOptions as ExtendedExecSyncOptions;
-    }
-
-    if (!silentMode) {
-      console.log(`[CommandExecutor] Executing: ${actualCommand} in ${cwd}`);
-    }
-
     // Get enhanced shell PATH
     const shellPath = getShellPath();
 
+    if (wslContext) {
+      // Invoke wsl.exe directly via execFileSync — bypasses cmd.exe entirely,
+      // avoiding all cmd.exe escaping issues (%, ^, &, etc.)
+      const wslCwd = typeof cwd === 'string' ? cwd : undefined;
+      const { file, args } = getWSLExecArgs(command, wslContext.distribution, wslCwd);
+
+      if (!silentMode) {
+        console.log(`[CommandExecutor] Executing (WSL): ${file} ${args.join(' ')} in ${cwd}`);
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { cwd: _cwd, silent: _silent, ...cleanOptions } = extendedOptions || {};
+      const wslOptions = {
+        ...cleanOptions,
+        maxBuffer: cleanOptions?.maxBuffer || 10 * 1024 * 1024,
+        encoding: (cleanOptions?.encoding || 'utf-8') as BufferEncoding,
+        env: { ...process.env, ...cleanOptions?.env, PATH: shellPath },
+      };
+
+      try {
+        const result = nodeExecFileSync(file, args, wslOptions);
+
+        if (result && !silentMode) {
+          const resultStr = result.toString();
+          const lines = resultStr.split('\n');
+          const preview = lines[0].substring(0, 100) +
+                          (lines.length > 1 ? ` ... (${lines.length} lines)` : '');
+          console.log(`[CommandExecutor] Success: ${preview}`);
+        }
+
+        return result;
+      } catch (error: unknown) {
+        if (!silentMode) {
+          console.error(`[CommandExecutor] Failed (WSL): ${command}`);
+          console.error(`[CommandExecutor] Error: ${error instanceof Error ? error.message : String(error)}`);
+        }
+        throw error;
+      }
+    }
+
+    if (!silentMode) {
+      console.log(`[CommandExecutor] Executing: ${command} in ${cwd}`);
+    }
+
     // Merge enhanced PATH into options (but remove our custom silent flag)
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { silent: _silent, ...cleanOptions } = actualOptions || {};
+    const { silent: _silent, ...cleanOptions } = extendedOptions || {};
     const enhancedOptions = {
       ...cleanOptions,
       maxBuffer: cleanOptions?.maxBuffer || 10 * 1024 * 1024,
@@ -58,7 +85,7 @@ class CommandExecutor {
     };
 
     try {
-      const result = nodeExecSync(actualCommand, enhancedOptions as ExecSyncOptions);
+      const result = nodeExecSync(command, enhancedOptions as ExecSyncOptions);
 
       // Log success with a preview of the result (unless silent mode)
       if (result && !silentMode) {
@@ -73,7 +100,7 @@ class CommandExecutor {
     } catch (error: unknown) {
       // Log error (unless silent mode)
       if (!silentMode) {
-        console.error(`[CommandExecutor] Failed: ${actualCommand}`);
+        console.error(`[CommandExecutor] Failed: ${command}`);
         console.error(`[CommandExecutor] Error: ${error instanceof Error ? error.message : String(error)}`);
       }
 
@@ -82,48 +109,65 @@ class CommandExecutor {
   }
 
   async execAsync(command: string, options?: ExecOptions & { timeout?: number }, wslContext?: WSLContext | null): Promise<{ stdout: string; stderr: string }> {
-    // Log the command being executed
     const cwd = options?.cwd || process.cwd();
-
-    // Handle WSL command wrapping
-    let actualCommand = command;
-    let actualOptions = options;
-
-    if (wslContext) {
-      // Extract cwd for WSL (it's a Linux path)
-      const wslCwd = typeof cwd === 'string' ? cwd : undefined;
-      actualCommand = wrapCommandForWSL(command, wslContext.distribution, wslCwd);
-      // WSL handles cwd internally, remove it from options
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { cwd: _cwd, ...cleanOptions } = options || {};
-      actualOptions = cleanOptions;
-    }
-
-    console.log(`[CommandExecutor] Executing async: ${actualCommand} in ${cwd}`);
-
-    // Get enhanced shell PATH
     const shellPath = getShellPath();
 
-    // Defaults: 60s timeout, 10MB buffer — git commands on large repos need both
-    const timeout = actualOptions?.timeout || 60_000;
-    const maxBuffer = actualOptions?.maxBuffer || 10 * 1024 * 1024;
+    if (wslContext) {
+      // Invoke wsl.exe directly via execFile — bypasses cmd.exe entirely
+      const wslCwd = typeof cwd === 'string' ? cwd : undefined;
+      const { file, args } = getWSLExecArgs(command, wslContext.distribution, wslCwd);
 
-    // Merge enhanced PATH into options
+      console.log(`[CommandExecutor] Executing async (WSL): ${file} ${args.join(' ')} in ${cwd}`);
+
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { cwd: _cwd, ...cleanOptions } = options || {};
+      const timeout = cleanOptions?.timeout || 60_000;
+      const maxBuffer = cleanOptions?.maxBuffer || 10 * 1024 * 1024;
+      const wslOptions: ExecFileOptions = {
+        ...cleanOptions,
+        timeout,
+        maxBuffer,
+        env: { ...process.env, ...cleanOptions?.env, PATH: shellPath },
+      };
+
+      try {
+        const result = await nodeExecFileAsync(file, args, wslOptions);
+
+        if (result.stdout) {
+          const stdout = String(result.stdout);
+          const lines = stdout.split('\n');
+          const preview = lines[0].substring(0, 100) +
+                          (lines.length > 1 ? ` ... (${lines.length} lines)` : '');
+          console.log(`[CommandExecutor] Async Success: ${preview}`);
+        }
+
+        return { stdout: String(result.stdout), stderr: String(result.stderr) };
+      } catch (error: unknown) {
+        console.error(`[CommandExecutor] Async Failed (WSL): ${command}`);
+        console.error(`[CommandExecutor] Async Error: ${error instanceof Error ? error.message : String(error)}`);
+        throw error;
+      }
+    }
+
+    console.log(`[CommandExecutor] Executing async: ${command} in ${cwd}`);
+
+    const timeout = options?.timeout || 60_000;
+    const maxBuffer = options?.maxBuffer || 10 * 1024 * 1024;
+
     const enhancedOptions: ExecOptions = {
-      ...actualOptions,
+      ...options,
       timeout,
       maxBuffer,
       env: {
         ...process.env,
-        ...actualOptions?.env,
+        ...options?.env,
         PATH: shellPath
       }
     };
 
     try {
-      const result = await nodeExecAsync(actualCommand, enhancedOptions);
+      const result = await nodeExecAsync(command, enhancedOptions);
 
-      // Log success with a preview of the result
       if (result.stdout) {
         const stdout = String(result.stdout);
         const lines = stdout.split('\n');
@@ -134,10 +178,8 @@ class CommandExecutor {
 
       return { stdout: String(result.stdout), stderr: String(result.stderr) };
     } catch (error: unknown) {
-      // Log error
-      console.error(`[CommandExecutor] Async Failed: ${actualCommand}`);
+      console.error(`[CommandExecutor] Async Failed: ${command}`);
       console.error(`[CommandExecutor] Async Error: ${error instanceof Error ? error.message : String(error)}`);
-
       throw error;
     }
   }

--- a/main/src/utils/wslUtils.ts
+++ b/main/src/utils/wslUtils.ts
@@ -53,11 +53,9 @@ export function posixJoin(...segments: string[]): string {
 
 /**
  * Escape a string for use inside a bash -c "..." double-quoted context.
- * Only escapes bash special characters. Use escapeForCmdExecBashDoubleQuote()
- * when the command goes through cmd.exe (e.g., child_process.execSync).
+ * Only escapes bash special characters (\, ", `, $).
  */
 export function escapeForBashDoubleQuote(str: string): string {
-  // In double-quoted strings, escape: \ ` $ " !
   return str
     .replace(/\\/g, '\\\\')
     .replace(/"/g, '\\"')
@@ -66,27 +64,20 @@ export function escapeForBashDoubleQuote(str: string): string {
 }
 
 /**
- * Escape a string for use inside a bash -c "..." context that is executed
- * through Windows cmd.exe (e.g., via child_process.execSync/execAsync).
- * Escapes % for cmd.exe FIRST (% → %% prevents env var expansion), then
- * escapes bash double-quote special chars.
+ * Build args array for invoking wsl.exe directly via execFileSync/execFile.
+ * Bypasses cmd.exe entirely, avoiding all cmd.exe escaping issues (%, ^, &, etc.).
+ * If cwd provided, cd to it first inside the bash -c command.
  */
-export function escapeForCmdExecBashDoubleQuote(str: string): string {
-  return escapeForBashDoubleQuote(str.replace(/%/g, '%%'));
-}
-
-/**
- * Wrap a command to execute inside WSL via wsl.exe.
- * If cwd provided, cd to it first inside WSL.
- * Uses double-quoted bash -c "..." for Windows cmd.exe compatibility.
- */
-export function wrapCommandForWSL(command: string, distro: string, cwd?: string): string {
+export function getWSLExecArgs(command: string, distro: string, cwd?: string): { file: string; args: string[] } {
+  let bashCommand = command;
   if (cwd) {
-    const escapedCwd = escapeForCmdExecBashDoubleQuote(cwd);
-    const escapedCmd = escapeForCmdExecBashDoubleQuote(command);
-    return `wsl.exe -d ${distro} -- bash -c "cd '${escapedCwd}' && ${escapedCmd}"`;
+    const escapedCwd = escapeForBashDoubleQuote(cwd);
+    bashCommand = `cd '${escapedCwd}' && ${command}`;
   }
-  return `wsl.exe -d ${distro} -- bash -c "${escapeForCmdExecBashDoubleQuote(command)}"`;
+  return {
+    file: 'wsl.exe',
+    args: ['-d', distro, '--', 'bash', '-c', bashCommand],
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- Git history in the sidebar was showing raw format strings (`%x01%h%x00%p%x00%s%x00%ai%x00%an%x00%ae`) instead of parsed commit data on WSL projects
- Root cause: commit 01f9b4d added `%` → `%%` escaping in `wrapCommandForWSL` to prevent cmd.exe from interpreting git format specifiers, but `%%` only collapses to `%` in batch files — on the cmd.exe command line it stays as `%%`, mangling git's format output
- **Root fix**: bypass cmd.exe entirely by using `execFileSync`/`execFile` to invoke `wsl.exe` directly with an args array, instead of `execSync`/`exec` which always spawn `cmd.exe /c` on Windows
- This eliminates the entire class of cmd.exe escaping issues (`%`, `^`, `&`, `|`, `>`, `<`) and simplifies the WSL utility code

## Changes

- **`wslUtils.ts`**: Replace `wrapCommandForWSL()` and `escapeForCmdExecBashDoubleQuote()` with `getWSLExecArgs()` that returns `{ file, args }` for direct invocation
- **`commandExecutor.ts`**: WSL paths now use `execFileSync`/`execFile` with args array instead of string commands through `execSync`/`exec`

## Test plan

- [ ] Verify git history loads correctly in sidebar for WSL projects
- [ ] Verify git operations (diff, commit tracking, status) work on WSL projects
- [ ] Verify non-WSL projects are unaffected (those paths are unchanged)