### PR TITLE
fix: make keyboard shortcut displays platform-adaptive

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { useResizable } from './hooks/useResizable';
 import { useHotkey } from './hooks/useHotkey';
 import { useTerminalShortcuts } from './hooks/useTerminalShortcuts';
 import { useShortcutHintsOverlay } from './hooks/useShortcutHintsOverlay';
+import { formatKeyDisplay } from './utils/hotkeyUtils';
 import { ShortcutHintsOverlay } from './components/ShortcutHintsOverlay';
 import { Sidebar } from './components/Sidebar';
 import { SessionView } from './components/SessionView';
@@ -560,7 +561,7 @@ function App() {
               <button
                 onClick={() => setIsTokenTestOpen(false)}
                 className="absolute top-4 right-4 p-2 hover:bg-surface-hover rounded-lg transition-colors text-text-secondary hover:text-text-primary"
-                title="Close Token Test (Cmd/Ctrl + Shift + T)"
+                title={`Close Token Test (${formatKeyDisplay('mod+shift+t')})`}
               >
                 <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />

--- a/frontend/src/components/CommitDialog.tsx
+++ b/frontend/src/components/CommitDialog.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import { GitCommit } from 'lucide-react';
+import { formatKeyDisplay } from '../utils/hotkeyUtils';
 import { Modal, ModalHeader, ModalBody, ModalFooter } from './ui/Modal';
 import { Button } from './ui/Button';
 import { Textarea } from './ui/Textarea';
@@ -90,7 +91,7 @@ export const CommitDialog: React.FC<CommitDialogProps> = ({
         />
         
         <p className="mt-2 text-xs text-text-tertiary">
-          Press Ctrl+Enter (Cmd+Enter on Mac) to commit
+          Press {formatKeyDisplay('mod+enter')} to commit
         </p>
       </ModalBody>
 

--- a/frontend/src/components/Help.tsx
+++ b/frontend/src/components/Help.tsx
@@ -32,7 +32,7 @@ function KeyboardShortcutsSection() {
         <div className="space-y-2">
           <div className="flex justify-between items-center">
             <span className="text-text-secondary">Send Input / Continue Conversation</span>
-            <Kbd size="md">Cmd/Ctrl + Enter</Kbd>
+            <Kbd size="md">{formatKeyDisplay('mod+enter')}</Kbd>
           </div>
         </div>
         {/* Dynamic shortcuts from registry */}
@@ -147,7 +147,7 @@ export default function Help({ isOpen, onClose }: HelpProps) {
                   <h4 className="font-medium text-text-primary">Continuing Conversations</h4>
                   <ul className="list-disc list-inside text-text-secondary mt-1 space-y-1">
                     <li>Click on a stopped pane to resume it</li>
-                    <li>Use <Kbd size="md">Cmd/Ctrl + Enter</Kbd> to send input</li>
+                    <li>Use <Kbd size="md">{formatKeyDisplay('mod+enter')}</Kbd> to send input</li>
                     <li>Full conversation history is preserved</li>
                   </ul>
                 </div>

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -5,6 +5,7 @@ import { API } from '../utils/api';
 import { optIn, capture, captureAndOptOut } from '../services/posthog';
 import type { AppConfig, TerminalShortcut } from '../types/config';
 import { useConfigStore } from '../stores/configStore';
+import { formatKeyDisplay } from '../utils/hotkeyUtils';
 import { useSessionStore } from '../stores/sessionStore';
 import { panelApi } from '../services/panelApi';
 import {
@@ -1056,7 +1057,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
                     fullWidth
                   />
                   <p className="text-xs text-text-tertiary">
-                    {shortcut.key ? `Hotkey: Ctrl/Cmd + Alt + ${shortcut.key.toUpperCase()}` : 'Set a key (a-z) to assign a hotkey'}
+                    {shortcut.key ? `Hotkey: ${formatKeyDisplay('mod+alt+' + shortcut.key)}` : 'Set a key (a-z) to assign a hotkey'}
                   </p>
                 </div>
               ))}

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -412,7 +412,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
           const isEditing = editingPanelId === panel.id;
           const isDiffPanel = panel.type === 'diff';
           const displayTitle = isDiffPanel ? 'Diff' : panel.title;
-          const shortcutHint = index < 9 ? formatKeyDisplay(`alt+${index + 1}`) : undefined;
+          const shortcutHint = index < 9 ? hotkeyDisplay(`panel-tab-${index + 1}`) ?? undefined : undefined;
 
           const tab = (
             <div

--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -13,6 +13,7 @@ import { NotebookPreview } from './NotebookPreview';
 import { useResizablePanel } from '../../../hooks/useResizablePanel';
 import { ExplorerPanelState } from '../../../../../shared/types/panels';
 import { isMac, isWindows } from '../../../utils/platformUtils';
+import { formatKeyDisplay } from '../../../utils/hotkeyUtils';
 import { TerminalPopover, PopoverButton } from '../../terminal/TerminalPopover';
 
 interface FileItem {
@@ -391,7 +392,7 @@ function HeadlessFileTree({
           <button
             onClick={() => setShowSearch(prev => !prev)}
             className={`p-1 rounded text-text-tertiary hover:text-text-primary ${showSearch ? 'bg-surface-tertiary' : 'hover:bg-surface-hover'}`}
-            title="Search files (Cmd/Ctrl+F)"
+            title={`Search files (${formatKeyDisplay('mod+f')})`}
           >
             <Search className="w-4 h-4" />
           </button>
@@ -441,7 +442,7 @@ function HeadlessFileTree({
           </div>
           {searchQuery && (
             <div className="mt-1 text-xs text-text-tertiary">
-              Press ESC to clear • Cmd/Ctrl+F to toggle search
+              Press ESC to clear • {formatKeyDisplay('mod+f')} to toggle search
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- **Root-cause fix**: Panel tab tooltips showed wrong shortcuts (e.g. `⌥+1` instead of `⌘+⌥+1` on Mac) because `PanelTabBar` manually constructed the key string instead of reading from the hotkey registry. Now uses `hotkeyDisplay()` to read the actual registered hotkey.
- **Consistency fix**: Replaced all hardcoded "Cmd/Ctrl" shortcut strings across 6 files with platform-adaptive `formatKeyDisplay()` calls (shows `⌘` on Mac, `Ctrl` on Windows/Linux).

## Files changed
- `PanelTabBar.tsx` — root-cause: use `hotkeyDisplay()` instead of manual string construction
- `Help.tsx` — 2 hardcoded "Cmd/Ctrl + Enter" strings
- `CommitDialog.tsx` — 1 hardcoded string + added import
- `FileEditor.tsx` — 2 hardcoded strings + added import
- `Settings.tsx` — 1 hardcoded string + added import
- `App.tsx` — 1 hardcoded string (dev-only) + added import

## Test plan
- [ ] On Mac: hover panel tabs, verify tooltip shows `⌘ + ⌥ + 1` (not `⌥ + 1`)
- [ ] On Windows/Linux: hover panel tabs, verify tooltip shows `Ctrl + Alt + 1`
- [ ] Open Help dialog — verify "Send Input" shortcut is platform-adaptive
- [ ] Open commit dialog — verify hint text is platform-adaptive
- [ ] Open file editor — verify search button tooltip and hint are platform-adaptive
- [ ] Open Settings > Terminal Shortcuts — verify hotkey display is platform-adaptive