### PR TITLE
fix: handle pty resize race condition and WSL path separator mismatch

### DIFF
--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -467,7 +467,14 @@ export class TerminalPanelManager {
       return;
     }
 
-    terminal.pty.resize(cols, rows);
+    try {
+      terminal.pty.resize(cols, rows);
+    } catch (err) {
+      // PTY may have exited between the map lookup and the resize call
+      console.warn(`[TerminalPanelManager] Failed to resize terminal ${panelId}:`, err);
+      this.terminals.delete(panelId);
+      return;
+    }
     
     // Update panel state with new dimensions
     const panel = panelManager.getPanel(panelId);

--- a/main/src/services/worktreePoolManager.ts
+++ b/main/src/services/worktreePoolManager.ts
@@ -29,11 +29,11 @@ class WorktreePoolManager {
   // Path helpers (inlined — do NOT call WorktreeManager's private methods)
   // ---------------------------------------------------------------------------
 
-  private resolveBaseDir(projectPath: string, worktreeFolder: string | undefined): string {
+  private resolveBaseDir(projectPath: string, worktreeFolder: string | undefined, pathResolver: PathResolver): string {
     if (worktreeFolder && (worktreeFolder.startsWith('/') || worktreeFolder.includes(':'))) {
       return worktreeFolder;
     }
-    return path.join(projectPath, worktreeFolder || 'worktrees');
+    return pathResolver.join(projectPath, worktreeFolder || 'worktrees');
   }
 
   private reserveKey(projectPath: string, baseRef: string): string {
@@ -68,7 +68,7 @@ class WorktreePoolManager {
     const hex = crypto.randomBytes(4).toString('hex'); // 8 hex chars
     const reserveName = `_reserve-${hex}`;
     const branchName = `_reserve/${hex}`;
-    const baseDir = this.resolveBaseDir(projectPath, worktreeFolder);
+    const baseDir = this.resolveBaseDir(projectPath, worktreeFolder, pathResolver);
     const reservePath = pathResolver.join(baseDir, reserveName);
 
     // Non-blocking fetch — ignore errors (user may be offline)
@@ -161,7 +161,7 @@ class WorktreePoolManager {
     // Remove from map immediately so nothing else claims this reserve
     this.reserves.delete(key);
 
-    const baseDir = this.resolveBaseDir(projectPath, worktreeFolder);
+    const baseDir = this.resolveBaseDir(projectPath, worktreeFolder, pathResolver);
     const targetPath = pathResolver.join(baseDir, targetName);
 
     try {


### PR DESCRIPTION
## Summary
- Wrap `pty.resize()` in try/catch in `terminalPanelManager` to prevent crash dialog when PTY has already exited but hasn't been cleaned up from the map yet
- Use `pathResolver.join()` instead of `path.join()` in `worktreePoolManager.resolveBaseDir()` to avoid mixed path separators on Windows with WSL project directories

## Test plan
- [ ] Create a new session, add a tool panel, rapidly switch between panels — should no longer see "Cannot resize a pty that has already exited" crash dialog
- [ ] On Windows with a WSL project directory, verify worktree pool creates reserves with correct forward-slash paths