### PR TITLE
fix: invert Ctrl+Tab and Ctrl+Shift+Tab to match standard conventions

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -189,8 +189,8 @@ export function ProjectSessionList({ sessionSortAscending }: ProjectSessionListP
 
   // Register session cycling hotkeys
   useEffect(() => {
-    const nextKeys = ['mod+shift+Tab', 'mod+ArrowDown'];
-    const prevKeys = ['mod+Tab', 'mod+ArrowUp'];
+    const nextKeys = ['mod+Tab', 'mod+ArrowDown'];
+    const prevKeys = ['mod+shift+Tab', 'mod+ArrowUp'];
     const ids: string[] = [];
 
     nextKeys.forEach((keys, i) => {


### PR DESCRIPTION
## Summary
- Swaps Ctrl+Tab and Ctrl+Shift+Tab keybindings so they match browser/IDE conventions
- Ctrl+Tab now cycles to **next** session, Ctrl+Shift+Tab cycles to **previous** session

## Test plan
- [ ] Verify Ctrl+Tab moves to the next session in the list
- [ ] Verify Ctrl+Shift+Tab moves to the previous session in the list
- [ ] Verify Ctrl+ArrowDown/Up still work as before (next/previous)