### PR TITLE
fix: prevent long names from overflowing terminal shortcuts overlay

### DIFF
--- a/frontend/src/components/ShortcutHintsOverlay.tsx
+++ b/frontend/src/components/ShortcutHintsOverlay.tsx
@@ -33,11 +33,11 @@ export function ShortcutHintsOverlay({ isVisible, shortcuts }: ShortcutHintsOver
         ) : (
           <div className="grid gap-2">
             {enabledShortcuts.map((s) => (
-              <div key={s.id} className="flex items-center gap-3 px-3 py-2 rounded-lg bg-surface-secondary">
+              <div key={s.id} className="flex items-center gap-3 px-3 py-2 rounded-lg bg-surface-secondary overflow-hidden">
                 <Kbd size="md" className="text-text-primary min-w-fit">
                   {modPrefix} + {s.key.toUpperCase()}
                 </Kbd>
-                <span className="text-sm text-text-secondary truncate">{s.label}</span>
+                <span className="text-sm text-text-secondary truncate min-w-0">{s.label}</span>
               </div>
             ))}
           </div>


### PR DESCRIPTION
## Summary
- Add `overflow-hidden` to shortcut row container and `min-w-0` to label span in `ShortcutHintsOverlay` so long shortcut names truncate instead of overflowing

## Test plan
- [ ] Configure a terminal shortcut with a long label
- [ ] Hold Ctrl+Alt to show the shortcuts overlay
- [ ] Verify long labels truncate with ellipsis instead of overflowing