### PR TITLE
fix: sanitize pane names instead of rejecting invalid characters

### DIFF
--- a/frontend/src/components/CreateSessionDialog.tsx
+++ b/frontend/src/components/CreateSessionDialog.tsx
@@ -364,10 +364,10 @@ export function CreateSessionDialog({
       let folderId: string | undefined = initialFolderId;
       if (shouldCreateFolder && projectId) {
         try {
-          const folderResponse = await API.folders.create(sessionName, projectId);
+          const folderResponse = await API.folders.create(cleanedName, projectId);
           if (folderResponse.success && folderResponse.data) {
             folderId = folderResponse.data.id;
-            console.log(`[CreateSessionDialog] Created folder: ${sessionName} (${folderId})`);
+            console.log(`[CreateSessionDialog] Created folder: ${cleanedName} (${folderId})`);
           }
         } catch (error) {
           console.error('[CreateSessionDialog] Failed to create folder:', error);
@@ -376,7 +376,7 @@ export function CreateSessionDialog({
       }
 
       console.log('[CreateSessionDialog] Creating session with:', {
-        sessionName,
+        sessionName: cleanedName,
         count: sessionCount,
         toolType: 'none',
         folderId
@@ -384,7 +384,7 @@ export function CreateSessionDialog({
 
       const response = await API.sessions.create({
         prompt: '',
-        worktreeTemplate: sessionName,
+        worktreeTemplate: cleanedName,
         count: sessionCount,
         toolType: 'none',
         permissionMode: 'ignore',


### PR DESCRIPTION
## Summary
- Replace frontend validation that blocked names with git-invalid characters (`~^:?*[]\`) with automatic sanitization that silently strips them
- Users can now paste PR titles or any text as pane names without hitting validation errors
- The backend already sanitizes for worktree/branch names, so the frontend was just being unnecessarily strict

## Test plan
- [ ] Create a pane with a name containing `~^:?*[]\` characters — they should be silently stripped
- [ ] Paste a PR title like `Error: Failed to process successful response` — colon should be stripped, name accepted
- [ ] Verify names with consecutive dots (`..`) get collapsed to single dot
- [ ] Verify leading/trailing dots and slashes are trimmed
- [ ] Verify empty-after-sanitization names show an error on submit