### PR TITLE
fix: macOS terminal popover actions (Open URL / Show in Explorer)

### DIFF
--- a/main/src/ipc/app.ts
+++ b/main/src/ipc/app.ts
@@ -1,5 +1,5 @@
 import { IpcMain, shell } from 'electron';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import type { AppServices } from './types';
 
 export function registerAppHandlers(ipcMain: IpcMain, services: AppServices): void {
@@ -25,7 +25,7 @@ export function registerAppHandlers(ipcMain: IpcMain, services: AppServices): vo
         // On macOS, shell.openExternal can fail silently due to permission/entitlement issues.
         // Use the native `open` command which works reliably.
         await new Promise<void>((resolve, reject) => {
-          exec(`open ${JSON.stringify(url)}`, (error) => {
+          execFile('open', [url], (error) => {
             if (error) reject(error);
             else resolve();
           });
@@ -54,7 +54,7 @@ export function registerAppHandlers(ipcMain: IpcMain, services: AppServices): vo
         // On macOS, shell.showItemInFolder can fail silently.
         // Use `open -R` which reveals the file in Finder reliably.
         await new Promise<void>((resolve, reject) => {
-          exec(`open -R ${JSON.stringify(filePath)}`, (error) => {
+          execFile('open', ['-R', filePath], (error) => {
             if (error) reject(error);
             else resolve();
           });


### PR DESCRIPTION
## Summary
- On macOS, the xterm terminal popover actions ("Open URL" and "Show in Explorer") fail silently because Electron's `shell.openExternal()` and `shell.showItemInFolder()` can have permission/entitlement issues
- Uses native `open` and `open -R` commands on macOS which work reliably regardless of app signing state
- Windows/Linux behavior is unchanged

## Test plan
- [ ] On macOS: Cmd+Click a file path in the terminal → popover appears → "Show in Explorer" opens Finder
- [ ] On macOS: Select a URL in terminal → popover "Open URL" opens default browser
- [ ] On Windows: Ctrl+Click file path → "Show in Explorer" still opens Windows Explorer
- [ ] On Windows: Select URL → "Open URL" still opens default browser