### PR TITLE
fix: support TUI apps (vim, nano, htop) in terminal panels

### DIFF
--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -27,6 +27,17 @@ const TUI_APPS = new Set([
   'tmux', 'screen', 'emacs', 'micro', 'helix', 'mc', 'ranger', 'lazygit',
 ]);
 
+/**
+ * Extract the bare process name from a process title that may be a full path.
+ * Handles both Unix (/usr/bin/vim) and Windows (C:\...\nvim.exe) formats.
+ */
+function extractProcessName(title: string): string {
+  // Split on both forward and back slashes, take the last segment
+  const basename = title.split(/[/\\]/).pop() || '';
+  // Strip a trailing .exe (case-insensitive) for Windows
+  return basename.replace(/\.exe$/i, '').toLowerCase();
+}
+
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
 const TerminalSpinner: React.FC = () => {
@@ -736,8 +747,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           // Track foreground process for TUI key passthrough
           const unsubscribeTitleChange = window.electronAPI.events.onTerminalTitleChanged((data: { panelId: string; processTitle: string }) => {
             if (data.panelId === panel.id) {
-              const processName = data.processTitle.split('/').pop()?.toLowerCase() || '';
-              tuiActiveRef.current = TUI_APPS.has(processName);
+              tuiActiveRef.current = TUI_APPS.has(extractProcessName(data.processTitle));
             }
           });
 
@@ -748,8 +758,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           window.electronAPI.invoke('terminal:getProcessTitle', panel.id)
             .then((title: unknown) => {
               if (disposed || typeof title !== 'string') return;
-              const processName = title.split('/').pop()?.toLowerCase() || '';
-              tuiActiveRef.current = TUI_APPS.has(processName);
+              tuiActiveRef.current = TUI_APPS.has(extractProcessName(title));
             })
             .catch(() => { /* terminal may not exist yet — ignore */ });
 

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -744,10 +744,19 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           const unsubscribeOutput = window.electronAPI.events.onTerminalOutput(outputHandler);
           console.log('[TerminalPanel] Subscribed to terminal output events for panel:', panel.id);
 
-          // Track foreground process for TUI key passthrough
+          // Track foreground process for TUI key passthrough.
+          // Two complementary signals are used:
+          //   1. Process title (works on native shells; unreliable on WSL where it reports wsl.exe)
+          //   2. Alternate screen buffer (works universally — emitted when vim/less/etc. enter/exit)
           const unsubscribeTitleChange = window.electronAPI.events.onTerminalTitleChanged((data: { panelId: string; processTitle: string }) => {
             if (data.panelId === panel.id) {
               tuiActiveRef.current = TUI_APPS.has(extractProcessName(data.processTitle));
+            }
+          });
+
+          const unsubscribeAltScreen = window.electronAPI.events.onTerminalAlternateScreen((data: { panelId: string; active: boolean }) => {
+            if (data.panelId === panel.id) {
+              tuiActiveRef.current = data.active;
             }
           });
 
@@ -755,17 +764,22 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           // left open and the panel remounted). Without this, tuiActiveRef
           // stays false until the next onData from the PTY triggers a title
           // change event, which may never happen if the TUI is idle.
-          window.electronAPI.invoke('terminal:getProcessTitle', panel.id)
-            .then((title: unknown) => {
-              if (disposed || typeof title !== 'string') return;
-              tuiActiveRef.current = TUI_APPS.has(extractProcessName(title));
+          window.electronAPI.invoke('terminal:getProcessInfo', panel.id)
+            .then((info: unknown) => {
+              if (disposed || !info || typeof info !== 'object') return;
+              const { processTitle, isAlternateScreen } = info as { processTitle: string; isAlternateScreen: boolean };
+              tuiActiveRef.current = isAlternateScreen || TUI_APPS.has(extractProcessName(processTitle));
             })
             .catch(() => { /* terminal may not exist yet — ignore */ });
 
           // Handle terminal process exit
           const unsubscribeExited = window.electronAPI.events.onTerminalExited((data: { sessionId: string; panelId: string; exitCode: number }) => {
-            if (data.panelId === panel.id && terminal && !disposed) {
-              terminal.write(`\r\n\x1b[90m[Process exited with code ${data.exitCode}]\x1b[0m\r\n`);
+            if (data.panelId === panel.id) {
+              // Reset TUI passthrough so Pane shortcuts work again on the dead terminal
+              tuiActiveRef.current = false;
+              if (terminal && !disposed) {
+                terminal.write(`\r\n\x1b[90m[Process exited with code ${data.exitCode}]\x1b[0m\r\n`);
+              }
             }
           });
 
@@ -835,6 +849,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             if (resizeTimer) clearTimeout(resizeTimer);
             unsubscribeOutput();
             unsubscribeTitleChange();
+            unsubscribeAltScreen();
             unsubscribeExited();
             unsubscribeFontUpdate();
             inputDisposable.dispose();

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -21,6 +21,12 @@ import { TerminalSearchOverlay } from '../terminal/TerminalSearchOverlay';
 import type { TerminalPanelState } from '../../../../shared/types/panels';
 import '@xterm/xterm/css/xterm.css';
 
+/** Full-screen TUI apps that need all keys passed through to the PTY */
+const TUI_APPS = new Set([
+  'vim', 'vi', 'nvim', 'nano', 'htop', 'top', 'btop', 'less', 'man',
+  'tmux', 'screen', 'emacs', 'micro', 'helix', 'mc', 'ranger', 'lazygit',
+]);
+
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
 const TerminalSpinner: React.FC = () => {
@@ -64,6 +70,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   const unicode11AddonRef = useRef<Unicode11Addon | null>(null);
   const isActiveRef = useRef(isActive);
   const isNearBottomRef = useRef(true); // Track if user is scrolled near the bottom
+  const tuiActiveRef = useRef(false);
   const [isInitialized, setIsInitialized] = useState(false);
   const [initError, setInitError] = useState<string | null>(null);
 
@@ -194,9 +201,15 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           // Initialize backend PTY process
           console.log('[TerminalPanel] Initializing backend PTY process...');
           // Use workingDirectory and sessionId if available, but don't require them
+          // Use actual container dimensions for PTY spawn (falls back to 80x30 on backend)
+          const containerRect = terminalRef.current?.getBoundingClientRect();
+          const estimatedCols = containerRect ? Math.floor(containerRect.width / 8) : undefined; // rough char width estimate
+          const estimatedRows = containerRect ? Math.floor(containerRect.height / 17) : undefined; // rough char height estimate
           await window.electronAPI.invoke('panels:initialize', panel.id, {
             cwd: workingDirectory || process.cwd(),
-            sessionId: sessionId || panel.sessionId
+            sessionId: sessionId || panel.sessionId,
+            cols: estimatedCols && estimatedCols >= 20 ? estimatedCols : undefined,
+            rows: estimatedRows && estimatedRows >= 5 ? estimatedRows : undefined,
           });
           console.log('[TerminalPanel] Backend PTY process initialized');
         } else {
@@ -258,6 +271,9 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
         // Intercept app-level shortcuts before xterm consumes them
         terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+          // When a TUI app is running, pass ALL keys through to the PTY
+          if (tuiActiveRef.current) return true;
+
           const ctrlOrMeta = e.ctrlKey || e.metaKey;
 
           // Ctrl/Cmd+1-9: switch sessions
@@ -456,7 +472,6 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           // Ack batching for flow control
           const ACK_BATCH_SIZE = 10_000; // 10KB
           const ACK_BATCH_INTERVAL = 100; // ms
-          const ACK_HEARTBEAT_INTERVAL = 500; // ms - safety heartbeat to flush any pending acks
           let pendingAckBytes = 0;
           let ackFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -471,9 +486,6 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
               window.electronAPI.invoke('terminal:ack', panel.id, bytes);
             }
           };
-
-          // Heartbeat: periodically flush any pending acks as a safety net
-          const heartbeatInterval = setInterval(flushAck, ACK_HEARTBEAT_INTERVAL);
 
           // Periodically save serialized snapshot so it's available on app quit
           // (main process can't call SerializeAddon — only the renderer can)
@@ -693,20 +705,18 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             if (data && typeof data === 'object' && 'panelId' in data && data.panelId && 'output' in data) {
               const typedData = data as { panelId: string; output: string };
               if (typedData.panelId === panel.id && terminal && !disposed) {
-                // FIX: Send ack IMMEDIATELY when data is received, not when write completes
-                // This prevents PTY from pausing when XTerm is overwhelmed by high-frequency TUI updates
-                pendingAckBytes += typedData.output.length;
-                if (pendingAckBytes >= ACK_BATCH_SIZE) {
-                  flushAck();
-                } else if (!ackFlushTimer) {
-                  ackFlushTimer = setTimeout(flushAck, ACK_BATCH_INTERVAL);
-                }
-
-                // Write to terminal — if user is near bottom, snap back after write
-                // completes to prevent the viewport jumping to top on large output chunks
                 const shouldSnap = isNearBottomRef.current;
+                const outputLength = typedData.output.length;
                 terminal.write(typedData.output, () => {
-                  if (shouldSnap && terminal && !disposed) {
+                  if (disposed) return;
+                  // Ack AFTER xterm has rendered the data — proper backpressure
+                  pendingAckBytes += outputLength;
+                  if (pendingAckBytes >= ACK_BATCH_SIZE) {
+                    flushAck();
+                  } else if (!ackFlushTimer) {
+                    ackFlushTimer = setTimeout(flushAck, ACK_BATCH_INTERVAL);
+                  }
+                  if (shouldSnap && terminal) {
                     terminal.scrollToBottom();
                   }
                 });
@@ -717,6 +727,21 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
           const unsubscribeOutput = window.electronAPI.events.onTerminalOutput(outputHandler);
           console.log('[TerminalPanel] Subscribed to terminal output events for panel:', panel.id);
+
+          // Track foreground process for TUI key passthrough
+          const unsubscribeTitleChange = window.electronAPI.events.onTerminalTitleChanged((data: { panelId: string; processTitle: string }) => {
+            if (data.panelId === panel.id) {
+              const processName = data.processTitle.split('/').pop()?.toLowerCase() || '';
+              tuiActiveRef.current = TUI_APPS.has(processName);
+            }
+          });
+
+          // Handle terminal process exit
+          const unsubscribeExited = window.electronAPI.events.onTerminalExited((data: { sessionId: string; panelId: string; exitCode: number }) => {
+            if (data.panelId === panel.id && terminal && !disposed) {
+              terminal.write(`\r\n\x1b[90m[Process exited with code ${data.exitCode}]\x1b[0m\r\n`);
+            }
+          });
 
           // Subscribe to live terminal font updates from Settings
           const unsubscribeFontUpdate = window.electronAPI.events.onTerminalFontUpdated((data: { terminalFontFamily: string; terminalFontSize: number }) => {
@@ -777,13 +802,14 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           const terminalElement = terminalRef.current;
           return () => {
             disposed = true;
-            clearInterval(heartbeatInterval);
             clearInterval(snapshotInterval);
             flushAck();
             if (ackFlushTimer) clearTimeout(ackFlushTimer);
             resizeObserver.disconnect();
             if (resizeTimer) clearTimeout(resizeTimer);
             unsubscribeOutput();
+            unsubscribeTitleChange();
+            unsubscribeExited();
             unsubscribeFontUpdate();
             inputDisposable.dispose();
             scrollDisposable.dispose();

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -21,23 +21,6 @@ import { TerminalSearchOverlay } from '../terminal/TerminalSearchOverlay';
 import type { TerminalPanelState } from '../../../../shared/types/panels';
 import '@xterm/xterm/css/xterm.css';
 
-/** Full-screen TUI apps that need all keys passed through to the PTY */
-const TUI_APPS = new Set([
-  'vim', 'vi', 'nvim', 'nano', 'htop', 'top', 'btop', 'less', 'man',
-  'tmux', 'screen', 'emacs', 'micro', 'helix', 'mc', 'ranger', 'lazygit',
-]);
-
-/**
- * Extract the bare process name from a process title that may be a full path.
- * Handles both Unix (/usr/bin/vim) and Windows (C:\...\nvim.exe) formats.
- */
-function extractProcessName(title: string): string {
-  // Split on both forward and back slashes, take the last segment
-  const basename = title.split(/[/\\]/).pop() || '';
-  // Strip a trailing .exe (case-insensitive) for Windows
-  return basename.replace(/\.exe$/i, '').toLowerCase();
-}
-
 const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 
 const TerminalSpinner: React.FC = () => {
@@ -744,16 +727,9 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           const unsubscribeOutput = window.electronAPI.events.onTerminalOutput(outputHandler);
           console.log('[TerminalPanel] Subscribed to terminal output events for panel:', panel.id);
 
-          // Track foreground process for TUI key passthrough.
-          // Two complementary signals are used:
-          //   1. Process title (works on native shells; unreliable on WSL where it reports wsl.exe)
-          //   2. Alternate screen buffer (works universally — emitted when vim/less/etc. enter/exit)
-          const unsubscribeTitleChange = window.electronAPI.events.onTerminalTitleChanged((data: { panelId: string; processTitle: string }) => {
-            if (data.panelId === panel.id) {
-              tuiActiveRef.current = TUI_APPS.has(extractProcessName(data.processTitle));
-            }
-          });
-
+          // Detect full-screen TUI apps (vim, htop, etc.) via alternate screen buffer.
+          // This is universal — all well-behaved TUI apps enter alternate screen via
+          // \x1b[?1049h and leave via \x1b[?1049l. No hardcoded app list needed.
           const unsubscribeAltScreen = window.electronAPI.events.onTerminalAlternateScreen((data: { panelId: string; active: boolean }) => {
             if (data.panelId === panel.id) {
               tuiActiveRef.current = data.active;
@@ -761,14 +737,12 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           });
 
           // Initialize TUI mode for already-running programs (e.g. vim was
-          // left open and the panel remounted). Without this, tuiActiveRef
-          // stays false until the next onData from the PTY triggers a title
-          // change event, which may never happen if the TUI is idle.
-          window.electronAPI.invoke('terminal:getProcessInfo', panel.id)
+          // left open and the panel remounted).
+          window.electronAPI.invoke('terminal:getAltScreenState', panel.id)
             .then((info: unknown) => {
-              if (disposed || !info || typeof info !== 'object') return;
-              const { processTitle, isAlternateScreen } = info as { processTitle: string; isAlternateScreen: boolean };
-              tuiActiveRef.current = isAlternateScreen || TUI_APPS.has(extractProcessName(processTitle));
+              if (disposed || info == null || typeof info !== 'object') return;
+              const { isAlternateScreen } = info as { isAlternateScreen: boolean };
+              tuiActiveRef.current = isAlternateScreen;
             })
             .catch(() => { /* terminal may not exist yet — ignore */ });
 
@@ -848,7 +822,6 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             resizeObserver.disconnect();
             if (resizeTimer) clearTimeout(resizeTimer);
             unsubscribeOutput();
-            unsubscribeTitleChange();
             unsubscribeAltScreen();
             unsubscribeExited();
             unsubscribeFontUpdate();

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -271,8 +271,13 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
         // Intercept app-level shortcuts before xterm consumes them
         terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
-          // When a TUI app is running, pass ALL keys through to the PTY
-          if (tuiActiveRef.current) return true;
+          // When a TUI app is running, pass most keys through to the PTY
+          // but still let Ctrl/Cmd+V use the browser's native paste path
+          if (tuiActiveRef.current) {
+            const cm = e.ctrlKey || e.metaKey;
+            if (cm && e.key.toLowerCase() === 'v') return false;
+            return true;
+          }
 
           const ctrlOrMeta = e.ctrlKey || e.metaKey;
 
@@ -735,6 +740,18 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
               tuiActiveRef.current = TUI_APPS.has(processName);
             }
           });
+
+          // Initialize TUI mode for already-running programs (e.g. vim was
+          // left open and the panel remounted). Without this, tuiActiveRef
+          // stays false until the next onData from the PTY triggers a title
+          // change event, which may never happen if the TUI is idle.
+          window.electronAPI.invoke('terminal:getProcessTitle', panel.id)
+            .then((title: unknown) => {
+              if (disposed || typeof title !== 'string') return;
+              const processName = title.split('/').pop()?.toLowerCase() || '';
+              tuiActiveRef.current = TUI_APPS.has(processName);
+            })
+            .catch(() => { /* terminal may not exist yet — ignore */ });
 
           // Handle terminal process exit
           const unsubscribeExited = window.electronAPI.events.onTerminalExited((data: { sessionId: string; panelId: string; exitCode: number }) => {

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -271,6 +271,7 @@ interface ElectronAPI {
     onTerminalCliReady: (callback: (data: { panelId: string }) => void) => () => void;
     onTerminalExited: (callback: (data: { sessionId: string; panelId: string; exitCode: number }) => void) => () => void;
     onTerminalTitleChanged: (callback: (data: { panelId: string; processTitle: string }) => void) => () => void;
+    onTerminalAlternateScreen: (callback: (data: { panelId: string; active: boolean }) => void) => () => void;
     onMainLog: (callback: (level: string, message: string) => void) => () => void;
     onVersionUpdateAvailable: (callback: (versionInfo: VersionUpdateInfo) => void) => () => void;
     

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -270,7 +270,6 @@ interface ElectronAPI {
     onTerminalOutput: (callback: (output: { sessionId: string; data: string; type: 'stdout' | 'stderr' }) => void) => () => void;
     onTerminalCliReady: (callback: (data: { panelId: string }) => void) => () => void;
     onTerminalExited: (callback: (data: { sessionId: string; panelId: string; exitCode: number }) => void) => () => void;
-    onTerminalTitleChanged: (callback: (data: { panelId: string; processTitle: string }) => void) => () => void;
     onTerminalAlternateScreen: (callback: (data: { panelId: string; active: boolean }) => void) => () => void;
     onMainLog: (callback: (level: string, message: string) => void) => () => void;
     onVersionUpdateAvailable: (callback: (versionInfo: VersionUpdateInfo) => void) => () => void;

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -269,6 +269,8 @@ interface ElectronAPI {
     
     onTerminalOutput: (callback: (output: { sessionId: string; data: string; type: 'stdout' | 'stderr' }) => void) => () => void;
     onTerminalCliReady: (callback: (data: { panelId: string }) => void) => () => void;
+    onTerminalExited: (callback: (data: { sessionId: string; panelId: string; exitCode: number }) => void) => () => void;
+    onTerminalTitleChanged: (callback: (data: { panelId: string; processTitle: string }) => void) => () => void;
     onMainLog: (callback: (level: string, message: string) => void) => () => void;
     onVersionUpdateAvailable: (callback: (versionInfo: VersionUpdateInfo) => void) => () => void;
     

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -409,9 +409,9 @@ export function registerPanelHandlers(ipcMain: IpcMain, services: AppServices) {
     terminalPanelManager.resetFlowControl(panelId);
   });
 
-  // Get current foreground process title for TUI detection on panel mount
-  ipcMain.handle('terminal:getProcessTitle', async (_, panelId: string) => {
-    return terminalPanelManager.getProcessTitle(panelId);
+  // Get current foreground process info for TUI detection on panel mount
+  ipcMain.handle('terminal:getProcessInfo', async (_, panelId: string) => {
+    return terminalPanelManager.getProcessInfo(panelId);
   });
 
   // Save a pasted image to ~/.pane/images/ and return the file path with image number

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -288,7 +288,7 @@ export function registerPanelHandlers(ipcMain: IpcMain, services: AppServices) {
   });
   
   // Panel initialization (lazy loading)
-  ipcMain.handle('panels:initialize', async (_, panelId: string, options?: { cwd?: string; sessionId?: string }) => {
+  ipcMain.handle('panels:initialize', async (_, panelId: string, options?: { cwd?: string; sessionId?: string; cols?: number; rows?: number }) => {
 
     const panel = panelManager.getPanel(panelId);
     if (!panel) {
@@ -315,7 +315,8 @@ export function registerPanelHandlers(ipcMain: IpcMain, services: AppServices) {
         }
       }
 
-      await terminalPanelManager.initializeTerminal(panel, cwd, wslContext);
+      const initialDimensions = (options?.cols && options?.rows) ? { cols: options.cols, rows: options.rows } : undefined;
+      await terminalPanelManager.initializeTerminal(panel, cwd, wslContext, undefined, initialDimensions);
     }
 
     return true;

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -409,9 +409,9 @@ export function registerPanelHandlers(ipcMain: IpcMain, services: AppServices) {
     terminalPanelManager.resetFlowControl(panelId);
   });
 
-  // Get current foreground process info for TUI detection on panel mount
-  ipcMain.handle('terminal:getProcessInfo', async (_, panelId: string) => {
-    return terminalPanelManager.getProcessInfo(panelId);
+  // Get alternate screen state for TUI detection on panel mount
+  ipcMain.handle('terminal:getAltScreenState', async (_, panelId: string) => {
+    return terminalPanelManager.getAltScreenState(panelId);
   });
 
   // Save a pasted image to ~/.pane/images/ and return the file path with image number

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -409,6 +409,11 @@ export function registerPanelHandlers(ipcMain: IpcMain, services: AppServices) {
     terminalPanelManager.resetFlowControl(panelId);
   });
 
+  // Get current foreground process title for TUI detection on panel mount
+  ipcMain.handle('terminal:getProcessTitle', async (_, panelId: string) => {
+    return terminalPanelManager.getProcessTitle(panelId);
+  });
+
   // Save a pasted image to ~/.pane/images/ and return the file path with image number
   ipcMain.handle('terminal:paste-image', async (
     _,

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -576,6 +576,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
       return () => ipcRenderer.removeListener('terminal:titleChanged', wrappedCallback);
     },
 
+    onTerminalAlternateScreen: (callback: (data: { panelId: string; active: boolean }) => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent, data: { panelId: string; active: boolean }) => callback(data);
+      ipcRenderer.on('terminal:alternateScreen', wrappedCallback);
+      return () => ipcRenderer.removeListener('terminal:alternateScreen', wrappedCallback);
+    },
+
     // Spotlight events
     onSpotlightStatusChanged: (callback: (data: { sessionId: string; projectId: number; active: boolean }) => void) => {
       const wrappedCallback = (_event: Electron.IpcRendererEvent, data: { sessionId: string; projectId: number; active: boolean }) => callback(data);

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -570,12 +570,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
       return () => ipcRenderer.removeListener('terminal:exited', wrappedCallback);
     },
 
-    onTerminalTitleChanged: (callback: (data: { panelId: string; processTitle: string }) => void) => {
-      const wrappedCallback = (_event: Electron.IpcRendererEvent, data: { panelId: string; processTitle: string }) => callback(data);
-      ipcRenderer.on('terminal:titleChanged', wrappedCallback);
-      return () => ipcRenderer.removeListener('terminal:titleChanged', wrappedCallback);
-    },
-
     onTerminalAlternateScreen: (callback: (data: { panelId: string; active: boolean }) => void) => {
       const wrappedCallback = (_event: Electron.IpcRendererEvent, data: { panelId: string; active: boolean }) => callback(data);
       ipcRenderer.on('terminal:alternateScreen', wrappedCallback);

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -564,6 +564,18 @@ contextBridge.exposeInMainWorld('electronAPI', {
       return () => ipcRenderer.removeListener('terminal:cliReady', wrappedCallback);
     },
 
+    onTerminalExited: (callback: (data: { sessionId: string; panelId: string; exitCode: number }) => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent, data: { sessionId: string; panelId: string; exitCode: number }) => callback(data);
+      ipcRenderer.on('terminal:exited', wrappedCallback);
+      return () => ipcRenderer.removeListener('terminal:exited', wrappedCallback);
+    },
+
+    onTerminalTitleChanged: (callback: (data: { panelId: string; processTitle: string }) => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent, data: { panelId: string; processTitle: string }) => callback(data);
+      ipcRenderer.on('terminal:titleChanged', wrappedCallback);
+      return () => ipcRenderer.removeListener('terminal:titleChanged', wrappedCallback);
+    },
+
     // Spotlight events
     onSpotlightStatusChanged: (callback: (data: { sessionId: string; projectId: number; active: boolean }) => void) => {
       const wrappedCallback = (_event: Electron.IpcRendererEvent, data: { sessionId: string; projectId: number; active: boolean }) => callback(data);

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -746,6 +746,17 @@ export class TerminalPanelManager {
     return this.terminals.get(panelId)?.scrollbackBuffer ?? null;
   }
 
+  /**
+   * Returns the current foreground process title for a terminal panel.
+   * Used by the renderer to initialize TUI detection when a panel remounts
+   * while a full-screen program (e.g. vim) is already running.
+   */
+  getProcessTitle(panelId: string): string | null {
+    const terminal = this.terminals.get(panelId);
+    if (!terminal) return null;
+    return terminal.pty.process;
+  }
+
   saveSerializedSnapshot(panelId: string, serializedData: string): void {
     // Enforce 8MB per-snapshot limit
     const MAX_SNAPSHOT_SIZE = 8_000_000;

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -14,7 +14,6 @@ const HIGH_WATERMARK = 100_000; // 100KB — pause PTY when pending exceeds this
 const LOW_WATERMARK = 10_000;   // 10KB — resume PTY when pending drops below this
 const OUTPUT_BATCH_INTERVAL = 32; // ms (~30fps) — wider window reduces TUI flicker
 const OUTPUT_BATCH_SIZE = 131072; // 128KB — timer-based flush preferred; size trigger is safety net
-const OUTPUT_HARD_LIMIT = 1_048_576; // 1MB — drop oldest data if buffer grows unbounded (renderer frozen)
 const PAUSE_SAFETY_TIMEOUT = 5_000; // 5s — auto-resume PTY if no acks arrive (prevents permanent stall)
 const MAX_CONCURRENT_SPAWNS = 3;
 
@@ -34,6 +33,7 @@ interface TerminalProcess {
   // Output batching
   outputBuffer: string;
   outputFlushTimer: ReturnType<typeof setTimeout> | null;
+  lastProcessTitle: string;
 }
 
 export class TerminalPanelManager {
@@ -165,7 +165,7 @@ export class TerminalPanelManager {
     }
   }
 
-  async initializeTerminal(panel: ToolPanel, cwd: string, wslContext?: WSLContext | null, priority: number = 1): Promise<void> {
+  async initializeTerminal(panel: ToolPanel, cwd: string, wslContext?: WSLContext | null, priority: number = 1, initialDimensions?: { cols: number; rows: number }): Promise<void> {
     if (this.terminals.has(panel.id)) {
       return;
     }
@@ -202,9 +202,9 @@ export class TerminalPanelManager {
 
     // Create PTY process with enhanced environment
     const ptyProcess = pty.spawn(shellPath, shellArgs, {
-      name: 'xterm-color',
-      cols: 80,
-      rows: 30,
+      name: 'xterm-256color',
+      cols: initialDimensions?.cols || 80,
+      rows: initialDimensions?.rows || 30,
       cwd: spawnCwd,
       env: {
         ...process.env,
@@ -233,7 +233,8 @@ export class TerminalPanelManager {
       isPaused: false,
       pauseSafetyTimer: null,
       outputBuffer: '',
-      outputFlushTimer: null
+      outputFlushTimer: null,
+      lastProcessTitle: ''
     };
     
     // Store in map
@@ -373,7 +374,7 @@ export class TerminalPanelManager {
       isInitialized: true,
       cwd: cwd,
       shellType: path.basename(shellPath),
-      dimensions: { cols: 80, rows: 30 }
+      dimensions: { cols: initialDimensions?.cols || 80, rows: initialDimensions?.rows || 30 }
     } as TerminalPanelState;
 
     await panelManager.updatePanel(panel.id, { state });
@@ -388,7 +389,19 @@ export class TerminalPanelManager {
     terminal.pty.onData((data: string) => {
       // Update last activity
       terminal.lastActivity = new Date();
-      
+
+      // Detect foreground process title changes (e.g. shell -> vim -> shell)
+      const currentTitle = terminal.pty.process;
+      if (currentTitle !== terminal.lastProcessTitle) {
+        terminal.lastProcessTitle = currentTitle;
+        if (mainWindow) {
+          mainWindow.webContents.send('terminal:titleChanged', {
+            panelId: terminal.panelId,
+            processTitle: currentTitle
+          });
+        }
+      }
+
       // Add to scrollback buffer
       this.addToScrollback(terminal, data);
       
@@ -428,11 +441,6 @@ export class TerminalPanelManager {
       
       // Buffer output for batching instead of sending immediately
       terminal.outputBuffer += data;
-
-      // Hard limit: if renderer is frozen and buffer grows unbounded, drop oldest data
-      if (terminal.outputBuffer.length > OUTPUT_HARD_LIMIT) {
-        terminal.outputBuffer = terminal.outputBuffer.slice(-OUTPUT_BATCH_SIZE);
-      }
 
       if (terminal.outputBuffer.length >= OUTPUT_BATCH_SIZE) {
         // Buffer is large enough — flush immediately

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -33,8 +33,7 @@ interface TerminalProcess {
   // Output batching
   outputBuffer: string;
   outputFlushTimer: ReturnType<typeof setTimeout> | null;
-  lastProcessTitle: string;
-  // Alternate screen buffer tracking (for TUI detection in WSL where pty.process is unreliable)
+  // Alternate screen buffer tracking — universal TUI detection signal
   isAlternateScreen: boolean;
 }
 
@@ -236,7 +235,6 @@ export class TerminalPanelManager {
       pauseSafetyTimer: null,
       outputBuffer: '',
       outputFlushTimer: null,
-      lastProcessTitle: '',
       isAlternateScreen: false
     };
     
@@ -393,19 +391,7 @@ export class TerminalPanelManager {
       // Update last activity
       terminal.lastActivity = new Date();
 
-      // Detect foreground process title changes (e.g. shell -> vim -> shell)
-      const currentTitle = terminal.pty.process;
-      if (currentTitle !== terminal.lastProcessTitle) {
-        terminal.lastProcessTitle = currentTitle;
-        if (mainWindow) {
-          mainWindow.webContents.send('terminal:titleChanged', {
-            panelId: terminal.panelId,
-            processTitle: currentTitle
-          });
-        }
-      }
-
-      // Detect alternate screen buffer enter/exit for reliable TUI detection
+      // Detect alternate screen buffer enter/exit for universal TUI detection
       // (works on WSL where pty.process reports wsl.exe instead of the Linux foreground app)
       // \x1b[?1049h = enter alternate screen, \x1b[?1049l = leave alternate screen
       const enterAlt = data.includes('\x1b[?1049h');
@@ -771,17 +757,14 @@ export class TerminalPanelManager {
   }
 
   /**
-   * Returns the current foreground process title and alternate screen state
-   * for a terminal panel.  Used by the renderer to initialize TUI detection
-   * when a panel remounts while a full-screen program is already running.
+   * Returns the alternate screen buffer state for a terminal panel.
+   * Used by the renderer to initialize TUI detection when a panel
+   * remounts while a full-screen program is already running.
    */
-  getProcessInfo(panelId: string): { processTitle: string; isAlternateScreen: boolean } | null {
+  getAltScreenState(panelId: string): { isAlternateScreen: boolean } | null {
     const terminal = this.terminals.get(panelId);
     if (!terminal) return null;
-    return {
-      processTitle: terminal.pty.process,
-      isAlternateScreen: terminal.isAlternateScreen
-    };
+    return { isAlternateScreen: terminal.isAlternateScreen };
   }
 
   saveSerializedSnapshot(panelId: string, serializedData: string): void {

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -34,6 +34,8 @@ interface TerminalProcess {
   outputBuffer: string;
   outputFlushTimer: ReturnType<typeof setTimeout> | null;
   lastProcessTitle: string;
+  // Alternate screen buffer tracking (for TUI detection in WSL where pty.process is unreliable)
+  isAlternateScreen: boolean;
 }
 
 export class TerminalPanelManager {
@@ -234,7 +236,8 @@ export class TerminalPanelManager {
       pauseSafetyTimer: null,
       outputBuffer: '',
       outputFlushTimer: null,
-      lastProcessTitle: ''
+      lastProcessTitle: '',
+      isAlternateScreen: false
     };
     
     // Store in map
@@ -399,6 +402,27 @@ export class TerminalPanelManager {
             panelId: terminal.panelId,
             processTitle: currentTitle
           });
+        }
+      }
+
+      // Detect alternate screen buffer enter/exit for reliable TUI detection
+      // (works on WSL where pty.process reports wsl.exe instead of the Linux foreground app)
+      // \x1b[?1049h = enter alternate screen, \x1b[?1049l = leave alternate screen
+      const enterAlt = data.includes('\x1b[?1049h');
+      const leaveAlt = data.includes('\x1b[?1049l');
+      if (enterAlt || leaveAlt) {
+        // If both appear in the same chunk, last one wins
+        const lastEnter = data.lastIndexOf('\x1b[?1049h');
+        const lastLeave = data.lastIndexOf('\x1b[?1049l');
+        const newState = lastEnter > lastLeave;
+        if (newState !== terminal.isAlternateScreen) {
+          terminal.isAlternateScreen = newState;
+          if (mainWindow) {
+            mainWindow.webContents.send('terminal:alternateScreen', {
+              panelId: terminal.panelId,
+              active: newState
+            });
+          }
         }
       }
 
@@ -747,14 +771,17 @@ export class TerminalPanelManager {
   }
 
   /**
-   * Returns the current foreground process title for a terminal panel.
-   * Used by the renderer to initialize TUI detection when a panel remounts
-   * while a full-screen program (e.g. vim) is already running.
+   * Returns the current foreground process title and alternate screen state
+   * for a terminal panel.  Used by the renderer to initialize TUI detection
+   * when a panel remounts while a full-screen program is already running.
    */
-  getProcessTitle(panelId: string): string | null {
+  getProcessInfo(panelId: string): { processTitle: string; isAlternateScreen: boolean } | null {
     const terminal = this.terminals.get(panelId);
     if (!terminal) return null;
-    return terminal.pty.process;
+    return {
+      processTitle: terminal.pty.process,
+      isAlternateScreen: terminal.isAlternateScreen
+    };
   }
 
   saveSerializedSnapshot(panelId: string, serializedData: string): void {


### PR DESCRIPTION
## Summary
- **Fix flow control**: Move acks inside `xterm.write()` callback for proper backpressure; remove 1MB data-drop hard limit that corrupted escape sequences mid-stream for TUI apps
- **Universal TUI detection via alternate screen buffer**: Detect `\x1b[?1049h` (enter) / `\x1b[?1049l` (leave) escape sequences — works for ALL full-screen apps (vim, nano, htop, tmux, any ncurses/crossterm app), through SSH, on WSL, no hardcoded app list needed
- **Key passthrough in TUI mode**: When alternate screen is active, pass all keys to PTY (except Ctrl+V for native paste) so vim/nano/htop keybindings work
- **Handle terminal:exited**: Frontend shows `[Process exited with code N]` when PTY dies, instead of silently hanging
- **Use actual container dimensions**: PTY spawns at the real terminal size instead of hardcoded 80x30
- **Fix PTY name mismatch**: `name` field now matches `TERM` env var (`xterm-256color`)

All existing battery optimizations preserved: 32ms output batching, active-panel-only resize, low scrollback.

## Test plan
- [ ] \`vim ~/.codex/config.toml\` — renders correctly, all keys work, \`:q\` exits cleanly
- [ ] \`htop\` — full-screen TUI renders, keys work, \`q\` exits, Pane shortcuts resume after exit
- [ ] \`ssh remote-host\` then \`vim\` on remote — TUI detected through SSH tunnel
- [ ] \`cat /dev/urandom | xxd\` — high-throughput output doesn't freeze or crash
- [ ] Normal shell usage — feels identical to before (ls, cd, git, etc.)
- [ ] Ctrl+V paste works both in normal shell and inside vim
- [ ] Exit a shell with \`exit\` — shows exit code message
- [ ] Resize terminal while vim is open — redraws correctly