### PR TITLE
fix: Shift+Enter sends newline in terminal panels

### DIFF
--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -273,6 +273,17 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             return true;
           }
 
+          // Shift+Enter: emit the same sequence as Alt+Enter (\x1b\r = ESC+CR)
+          // xterm.js ignores shiftKey on Enter, so Shift+Enter = Enter by default.
+          // Alt+Enter natively sends \x1b\r which CLI tools recognize as "insert newline".
+          // Block both keydown and keyup to fully suppress xterm's default \r.
+          if (e.shiftKey && e.key === 'Enter') {
+            if (e.type === 'keydown') {
+              window.electronAPI.invoke('terminal:input', panel.id, '\x1b\r');
+            }
+            return false;
+          }
+
           const ctrlOrMeta = e.ctrlKey || e.metaKey;
 
           // Ctrl/Cmd+1-9: switch sessions


### PR DESCRIPTION
## Summary
- xterm.js ignores the shift modifier on Enter, making Shift+Enter identical to plain Enter (`\r`)
- Intercept Shift+Enter in `attachCustomKeyEventHandler` and emit `\x1b\r` (ESC+CR) — the same sequence Alt+Enter produces natively
- CLI tools (Claude Code, etc.) already recognize this sequence as "insert newline without submitting"
- Works on all platforms

## Test plan
- [ ] Press Shift+Enter in a terminal panel — should insert a newline, not submit
- [ ] Press Enter — should still submit as normal
- [ ] Press Alt/Option+Enter — should still insert a newline (unchanged native behavior)
- [ ] Verify TUI apps (vim, nano) still work normally