### PR TITLE
fix: normalize WSL relative paths in Explorer

### DIFF
--- a/main/src/utils/pathResolver.ts
+++ b/main/src/utils/pathResolver.ts
@@ -43,7 +43,11 @@ export class PathResolver {
 
   /** Compute relative path. Both arguments must be filesystem-format paths (UNC for WSL, native for other platforms). */
   relative(from: string, to: string): string {
-    return path.relative(from, to);
+    const rel = path.relative(from, to);
+    if (this.environment === 'wsl') {
+      return rel.replace(/\\/g, '/');
+    }
+    return rel;
   }
 
   /** Check if targetPath is within basePath — resolves symlinks. Both must be filesystem-format paths (UNC for WSL, native for other platforms). */


### PR DESCRIPTION
## Summary
- Fixes Explorer panel displaying garbled folder names (e.g., `apps□api□node_modules`) and flattened tree hierarchy when running in WSL
- Root cause: `PathResolver.relative()` returned backslash-separated paths on Windows, but the frontend expects forward slashes for tree parent-child resolution
- `PathResolver.join()` already handled this via `posixJoin()` — `relative()` was simply missed

## Test plan
- [ ] Open Pane in WSL, create a session, open Explorer tab
- [ ] Verify folder tree displays proper nested hierarchy (not flattened)
- [ ] Verify folder names show clean names (not full paths with □ characters)
- [ ] Verify file search works correctly in WSL (worktree filtering)
- [ ] Verify Explorer still works correctly on native Windows and macOS