### PR TITLE
feat: auto-bump WSL inotify limits on startup

### DIFF
--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -771,10 +771,13 @@ async function initializeServices() {
 
   // Bump WSL inotify limits if any WSL projects exist (limits don't persist across WSL reboots)
   if (process.platform === 'win32') {
-    const hasWSLProjects = databaseService.getAllProjects().some(p => p.wsl_enabled);
-    if (hasWSLProjects) {
-      const { bumpWSLInotifyLimits } = await import('./utils/wslUtils');
-      bumpWSLInotifyLimits();
+    const wslDistros = databaseService.getAllProjects()
+      .filter(p => p.wsl_enabled && p.wsl_distribution)
+      .map(p => p.wsl_distribution!);
+    if (wslDistros.length > 0) {
+      import('./utils/wslUtils').then(({ bumpWSLInotifyLimits }) =>
+        bumpWSLInotifyLimits(wslDistros).catch(() => {})
+      );
     }
   }
 

--- a/main/src/utils/wslUtils.ts
+++ b/main/src/utils/wslUtils.ts
@@ -121,19 +121,26 @@ export function getWSLContextFromProject(project: {
 /**
  * Bump inotify limits inside WSL so file watchers (Claude Code, VS Code, etc.) don't exhaust them.
  * WSL2 doesn't persist sysctl changes across reboots, so this runs on every app launch.
- * Uses -u root to avoid sudo password prompts. Fire-and-forget — failures are silently ignored.
+ * Uses -u root to avoid sudo password prompts. Async and fire-and-forget — failures are silently ignored.
  */
-export function bumpWSLInotifyLimits(): void {
-  if (process.platform !== 'win32') return;
+export async function bumpWSLInotifyLimits(distros: string[]): Promise<void> {
+  if (process.platform !== 'win32' || distros.length === 0) return;
 
-  try {
-    nodeExecSync(
-      'wsl.exe -u root -- sysctl -w fs.inotify.max_user_watches=2147483647 fs.inotify.max_user_instances=8192',
-      { encoding: 'utf-8', timeout: 10000, stdio: 'ignore' }
-    );
-  } catch {
-    // WSL not available or command failed — ignore
-  }
+  const { execFile } = await import('child_process');
+  const { promisify } = await import('util');
+  const execFileAsync = promisify(execFile);
+
+  const unique = [...new Set(distros)];
+  await Promise.allSettled(
+    unique.map(distro =>
+      execFileAsync('wsl.exe', [
+        '-d', distro, '-u', 'root', '--',
+        'sysctl', '-w',
+        'fs.inotify.max_user_watches=2147483647',
+        'fs.inotify.max_user_instances=8192',
+      ], { timeout: 10000 })
+    )
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- WSL2 doesn't persist sysctl settings across reboots, causing file watcher exhaustion when running Claude Code, VS Code, and other tools simultaneously
- Pane now bumps `max_user_watches` to INT_MAX and `max_user_instances` to 8192 on every launch when WSL projects exist
- Fire-and-forget via `wsl.exe -u root` — silently ignored if WSL unavailable

## Test plan
- [ ] Launch Pane with a WSL project configured
- [ ] Verify inotify limits are bumped (`cat /proc/sys/fs/inotify/max_user_watches` inside WSL should show 2147483647)
- [ ] Verify app startup is not noticeably delayed
- [ ] Verify non-WSL projects on native Windows are unaffected