### PR TITLE
fix: terminal focus stealing and browser panel hotkeys

### DIFF
--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1091,6 +1091,7 @@ export const SessionView = memo(() => {
                     <PanelContainer
                       panel={defaultTerminalPanel}
                       isActive={true}
+                      autoFocus={false}
                       isMainRepo={!!activeSession.isMainRepo}
                     />
                   </div>
@@ -1237,6 +1238,7 @@ export const SessionView = memo(() => {
                         <PanelContainer
                           panel={defaultTerminalPanel}
                           isActive={true}
+                          autoFocus={false}
                           isMainRepo={!!activeSession.isMainRepo}
                         />
                       </div>

--- a/frontend/src/components/panels/PanelContainer.tsx
+++ b/frontend/src/components/panels/PanelContainer.tsx
@@ -32,7 +32,8 @@ const PanelErrorFallback: React.FC<{ error: Error; resetErrorBoundary: () => voi
 export const PanelContainer: React.FC<PanelContainerProps> = React.memo(({
   panel,
   isActive,
-  isMainRepo = false
+  isMainRepo = false,
+  autoFocus
 }) => {
   renderLog('[PanelContainer] Rendering panel:', panel.id, 'Type:', panel.type, 'Active:', isActive);
   
@@ -46,7 +47,7 @@ export const PanelContainer: React.FC<PanelContainerProps> = React.memo(({
     // Panel type rendering
     switch (panel.type) {
       case 'terminal':
-        return <TerminalPanel panel={panel} isActive={isActive} />;
+        return <TerminalPanel panel={panel} isActive={isActive} autoFocus={autoFocus} />;
       case 'diff':
         return <DiffPanel panel={panel} isActive={isActive} sessionId={panel.sessionId} isMainRepo={isMainRepo} />;
       case 'explorer':
@@ -76,7 +77,7 @@ export const PanelContainer: React.FC<PanelContainerProps> = React.memo(({
           </div>
         );
     }
-  }, [panel, isActive, isMainRepo]); // Include panel to catch state changes
+  }, [panel, isActive, isMainRepo, autoFocus]); // Include panel to catch state changes
 
   return (
     <ErrorBoundary

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -57,7 +57,7 @@ function buildTerminalFontFamily(userFont: string): string {
   return `"${userFont}", "Symbols Nerd Font Mono", monospace`;
 }
 
-export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActive }) => {
+export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, isActive, autoFocus = true }) => {
   renderLog('[TerminalPanel] Component rendering, panel:', panel.id, 'isActive:', isActive);
   
   // All hooks must be called at the top level, before any conditional returns
@@ -1090,12 +1090,14 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
         if (rows > 0) {
           xtermRef.current!.refresh(0, rows - 1);
         }
-        xtermRef.current?.focus();
+        if (autoFocus) {
+          xtermRef.current?.focus();
+        }
       };
 
       requestAnimationFrame(fitTerminal);
     }
-  }, [isActive, panel.id, isInitialized]);
+  }, [isActive, panel.id, isInitialized, autoFocus]);
 
   useEffect(() => {
     if (!xtermRef.current) {

--- a/frontend/src/types/panelComponents.ts
+++ b/frontend/src/types/panelComponents.ts
@@ -22,9 +22,11 @@ export interface PanelContainerProps {
   panel: ToolPanel;
   isActive: boolean;
   isMainRepo?: boolean;
+  autoFocus?: boolean;
 }
 
 export interface TerminalPanelProps {
   panel: ToolPanel;
   isActive: boolean;
+  autoFocus?: boolean;
 }

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -260,6 +260,67 @@ async function createWindow() {
     });
     wvContents.setBackgroundThrottling(true);
 
+    // Forward app hotkeys from webview to renderer.
+    // Webviews are separate processes — keyboard events inside them never reach
+    // the renderer's window listener where the hotkey system lives. Only intercept
+    // the specific Ctrl/Cmd+key combos that Pane actually handles, so that normal
+    // browser shortcuts (Ctrl+F, Ctrl+R, Ctrl+A in inputs, etc.) still work
+    // inside embedded browser panels.
+    // Whitelist of Pane hotkeys that should be forwarded from webviews.
+    // mod+key (no extra modifiers):
+    const paneHotkeys: ReadonlySet<string> = new Set([
+      'k', 'b', ',', 'n', 'a', 'd', 'w', 't', '`',
+      // mod+1..9 switch session, mod+Tab/ArrowDown cycle next
+      '1', '2', '3', '4', '5', '6', '7', '8', '9',
+      'tab', 'arrowdown', 'arrowup',
+    ]);
+    // mod+shift+key — matched by physical key code (Digit/Key) because
+    // input.key reports the shifted symbol (e.g. '!' for Shift+1) which
+    // varies by keyboard layout.
+    const paneShiftCodes: ReadonlySet<string> = new Set([
+      'KeyE', 'KeyN', 'KeyK', 'KeyP', 'KeyZ', 'KeyL', 'KeyR', 'KeyM',
+      'KeyB', 'KeyW', 'KeyD',
+      'Digit1', 'Digit2', 'Digit3', 'Digit4', 'Digit5',
+      'Digit6', 'Digit7', 'Digit8', 'Digit9',
+      'Tab', // mod+shift+Tab cycles prev session
+    ]);
+    wvContents.on('before-input-event', (event, input) => {
+      if (input.type !== 'keyDown') return;
+      const mod = input.control || input.meta;
+      if (!mod) return;
+
+      const key = input.key.toLowerCase();
+      const code = input.code;
+
+      // Skip AltGr: on Windows/Linux international layouts, AltGr reports
+      // control+alt simultaneously. We detect this as control+alt without
+      // meta, and only forward when the physical key is a letter, digit,
+      // or slash (the patterns used by Pane's mod+alt shortcuts). This
+      // prevents blocking character input like @, €, or \ on those layouts.
+      const isAltGr = input.control && input.alt && !input.meta
+        && !/^(Key[A-Z]|Digit[0-9]|Slash)$/.test(code);
+
+      // Determine if this combo matches a registered Pane hotkey.
+      // mod+alt combos are forwarded (user-configurable terminal shortcuts
+      // use mod+alt+<key>), but AltGr character input is excluded above.
+      const isPaneHotkey =
+        (input.alt && !isAltGr) ||
+        (input.shift && !input.alt && paneShiftCodes.has(code)) ||
+        (!input.shift && !input.alt && paneHotkeys.has(key));
+
+      if (!isPaneHotkey) return;
+
+      event.preventDefault();
+      mainWindow?.webContents.send('synthetic-keydown', {
+        key: input.key,
+        code: input.code,
+        ctrlKey: input.control,
+        metaKey: input.meta,
+        shiftKey: input.shift,
+        altKey: input.alt,
+      });
+    });
+
     // Apply the same localhost header-stripping to the webview's session/partition.
     // Without this, webview partitions don't inherit the defaultSession's onHeadersReceived
     // hook, so localhost apps that send X-Frame-Options headers would be blocked.
@@ -356,7 +417,8 @@ async function createWindow() {
     if ((input.control || input.meta) && input.key.toLowerCase() === 'w' && input.type === 'keyDown') {
       event.preventDefault();
       mainWindow?.webContents.send('synthetic-keydown', {
-        key: 'w',
+        key: input.key,
+        code: input.code,
         ctrlKey: input.control,
         metaKey: input.meta,
         shiftKey: input.shift,

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -144,14 +144,15 @@ try {
     }
   });
 
-  // Bridge synthetic keydown events from main process (used for Ctrl+W interception)
-  // Main process intercepts Ctrl+W via before-input-event to prevent window close,
-  // then re-emits the key as a DOM KeyboardEvent so the renderer's hotkey system sees it.
-  ipcRenderer.on('synthetic-keydown', (_event: Electron.IpcRendererEvent, data: { key: string; ctrlKey: boolean; metaKey: boolean; shiftKey: boolean; altKey: boolean }) => {
+  // Bridge synthetic keydown events from main process (used for Ctrl+W interception
+  // and forwarding app hotkeys from webview panels whose keyboard events don't reach
+  // the renderer's window listener).
+  ipcRenderer.on('synthetic-keydown', (_event: Electron.IpcRendererEvent, data: { key: string; code?: string; ctrlKey: boolean; metaKey: boolean; shiftKey: boolean; altKey: boolean }) => {
     try {
       const target = document.activeElement || document.body;
       target.dispatchEvent(new KeyboardEvent('keydown', {
         key: data.key,
+        code: data.code,
         ctrlKey: data.ctrlKey,
         metaKey: data.metaKey,
         shiftKey: data.shiftKey,


### PR DESCRIPTION
## Summary
- Pinned terminal no longer auto-steals keyboard focus from the active tab panel (Claude Code, Codex, etc.) when switching sessions in either layout mode
- App hotkeys (Ctrl+A/D, Ctrl+Up/Down, Ctrl+Tab, Ctrl+1-9, etc.) now work when the browser panel webview is focused, forwarded via the existing synthetic-keydown IPC bridge

## Test plan
- [ ] Switch sessions in swapped layout — focus should stay on Claude Code panel, not jump to the right terminal rail
- [ ] Switch sessions in default layout with terminal expanded — same behavior
- [ ] In browser panel, press Ctrl+A/D to cycle tabs — should work
- [ ] In browser panel, press Ctrl+Up/Down to cycle sessions — should work
- [ ] In browser panel, Ctrl+C/V/X still work for copy/paste
- [ ] On international keyboard layouts, AltGr combos still produce special characters in browser panel