### PR TITLE
fix: expand/collapse buttons work in immersive mode (diff/explorer)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { useIPCEvents } from './hooks/useIPCEvents';
 import { useNotifications } from './hooks/useNotifications';
 import { useResizable } from './hooks/useResizable';
@@ -84,8 +84,23 @@ function App() {
   const [projects, setProjects] = useState<Project[]>([]);
   const activeProjectId = useNavigationStore(s => s.activeProjectId);
   const sidebarCollapsed = useNavigationStore(s => s.sidebarCollapsed);
-  const toggleSidebarCollapsed = useNavigationStore(s => s.toggleSidebarCollapsed);
+  const setSidebarCollapsed = useNavigationStore(s => s.setSidebarCollapsed);
   const immersiveMode = useNavigationStore(s => s.immersiveMode);
+  const setImmersiveMode = useNavigationStore(s => s.setImmersiveMode);
+
+  // When in immersive mode, the sidebar is forced collapsed.
+  // The toggle button needs to clear immersive mode to expand, not just toggle sidebarCollapsed.
+  const handleToggleSidebar = useCallback(() => {
+    const isVisuallyCollapsed = immersiveMode || sidebarCollapsed;
+    if (isVisuallyCollapsed) {
+      // User wants to expand
+      if (immersiveMode) setImmersiveMode(false);
+      if (sidebarCollapsed) setSidebarCollapsed(false);
+    } else {
+      // User wants to collapse
+      setSidebarCollapsed(true);
+    }
+  }, [immersiveMode, sidebarCollapsed, setImmersiveMode, setSidebarCollapsed]);
   const { currentError, clearError } = useErrorStore();
   const { sessions, isLoaded } = useSessionStore();
   const { fetchConfig, config: appConfig } = useConfigStore();
@@ -118,7 +133,7 @@ function App() {
     label: 'Toggle Sidebar',
     keys: 'mod+b',
     category: 'view',
-    action: toggleSidebarCollapsed,
+    action: handleToggleSidebar,
   });
 
   useHotkey({
@@ -135,7 +150,7 @@ function App() {
     keys: 'mod+shift+e',
     category: 'navigation',
     action: () => {
-      if (sidebarCollapsed) toggleSidebarCollapsed();
+      if (sidebarCollapsed || immersiveMode) handleToggleSidebar();
     },
   });
 
@@ -531,7 +546,7 @@ function App() {
             width={sidebarWidth}
             onResize={startResize}
             collapsed={sidebarCollapsed}
-            onToggleCollapse={toggleSidebarCollapsed}
+            onToggleCollapse={handleToggleSidebar}
             onHelpClick={() => setIsHelpOpen(true)}
           />
         </div>

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -727,6 +727,25 @@ export const SessionView = memo(() => {
     });
   }, []);
 
+  // Layout-aware detail panel toggle that also handles immersive mode override
+  const handleToggleDetailPanel = useCallback(() => {
+    if (immersiveMode) {
+      setImmersiveMode(false);
+      if (layoutSwapped) {
+        setIsDetailCollapsed(false);
+        localStorage.setItem('pane-detail-collapsed', 'false');
+      } else {
+        setDetailVisible(true);
+      }
+      return;
+    }
+    if (layoutSwapped) {
+      toggleDetailCollapse();
+    } else {
+      setDetailVisible(v => !v);
+    }
+  }, [immersiveMode, layoutSwapped, setImmersiveMode, toggleDetailCollapse]);
+
   // Terminal collapse state with localStorage persistence (collapsed by default)
   const [isTerminalCollapsed, setIsTerminalCollapsed] = useState(() => {
     const stored = localStorage.getItem('pane-terminal-collapsed');
@@ -758,13 +777,7 @@ export const SessionView = memo(() => {
     keys: 'mod+shift+b',
     category: 'view',
     enabled: () => isInSessionView,
-    action: () => {
-      if (layoutSwapped) {
-        toggleDetailCollapse();
-      } else {
-        setDetailVisible(v => !v);
-      }
-    },
+    action: handleToggleDetailPanel,
   });
 
   // Create branch actions for the panel bar
@@ -943,13 +956,7 @@ export const SessionView = memo(() => {
           onPanelSelect={handlePanelSelect}
           onPanelClose={handlePanelClose}
           onPanelCreate={handlePanelCreate}
-          onToggleDetailPanel={() => {
-            if (layoutSwapped) {
-              toggleDetailCollapse();
-            } else {
-              setDetailVisible(v => !v);
-            }
-          }}
+          onToggleDetailPanel={handleToggleDetailPanel}
           detailPanelVisible={detailVisible}
         />
 


### PR DESCRIPTION
## Summary
- Expand/collapse buttons for sidebar and detail panel now properly work when viewing diff or explorer panels (immersive mode)
- Previously, immersive mode forced both panels collapsed and the toggle buttons had no visible effect because `immersiveMode` took precedence over the individual collapsed states
- The fix clears `immersiveMode` when the user explicitly clicks expand, while preserving auto-collapse when first entering an immersive panel
- Consolidated duplicate detail panel toggle logic (hotkey, PanelTabBar, inline handler) into a single `handleToggleDetailPanel` callback

## Test plan
- [ ] Open a diff or explorer panel — sidebar and detail panel should auto-collapse
- [ ] Click the sidebar expand button — sidebar should expand
- [ ] Click the sidebar collapse button — sidebar should collapse back
- [ ] Use Cmd+B hotkey — should toggle sidebar even in immersive mode
- [ ] Use Cmd+Shift+E hotkey — should expand sidebar when in immersive mode
- [ ] Click the detail panel toggle in the tab bar — should show/hide detail panel
- [ ] Use Cmd+Shift+B hotkey — should toggle detail panel even in immersive mode
- [ ] Switch away from diff/explorer panel and back — immersive mode should re-engage (auto-collapse)
- [ ] Test in both default and swapped layout modes