### PR TITLE
fix: remove auto-enter on embed mode paste in @ terminal handler

### DIFF
--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -881,7 +881,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
                   lines,
                 );
                 if (response?.success && response.data && terminal && !disposed) {
-                  terminal.paste(`${response.data.filePath}\n`);
+                  terminal.paste(response.data.filePath);
                   setToastMessage(`Embedded ${response.data.lineCount} lines from ${response.data.panelTitle}`);
                 } else {
                   setToastMessage('Failed — no scrollback available');


### PR DESCRIPTION
## Summary
- Removes the trailing `\n` from embed mode paste in the `@` terminal handler, which was causing an unwanted auto-submit when selecting a file in embed mode

## Test plan
- [ ] Open a terminal panel, use `@` to reference another terminal in embed mode
- [ ] Verify the file path is pasted without triggering Enter