### PR TITLE
fix: capture-phase paste handler to prevent xterm double-paste on Windows/WSL

### DIFF
--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -592,8 +592,11 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           }
 
           // Handle paste events (Ctrl+V, voice transcription, external text injection)
-          // XTerm.js in Electron doesn't handle clipboard paste natively, so we
-          // intercept the paste event and feed it to the terminal explicitly
+          // Attached on the container in CAPTURE phase so we fire BEFORE xterm's own
+          // paste handler on the textarea.  When an image is detected we call
+          // stopPropagation() so xterm never sees the event — this prevents xterm from
+          // also pasting whatever text/plain happens to be in the clipboard alongside
+          // the image, which caused bare "[Image]" (no path) to appear on Windows/WSL.
           const handlePaste = (e: ClipboardEvent) => {
             // Check for images in browser clipboard first (works on native Windows/macOS)
             const items = e.clipboardData?.items;
@@ -602,6 +605,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
               for (let i = 0; i < items.length; i++) {
                 if (items[i].type.startsWith('image/')) {
                   foundBrowserImage = true;
+                  e.stopPropagation();
                   e.preventDefault();
                   const file = items[i].getAsFile();
                   if (!file) return;
@@ -649,6 +653,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
               // Only attempt fallback if there's no text being pasted,
               // or if text is empty (user likely intended to paste an image)
               if (!text) {
+                e.stopPropagation();
                 e.preventDefault();
                 (async () => {
                   if (disposed || !terminal) return;
@@ -667,20 +672,12 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
                 return;
               }
 
-              // Regular text paste — let xterm's built-in paste handler
-              // process it (it already listens for paste on its textarea).
-              // Calling terminal.paste() here would double-inject the text.
+              // Regular text paste — let event propagate to xterm's handler.
             }
           };
-          // Attach paste handler to xterm's internal textarea — xterm calls
-          // stopPropagation() on paste events so they never bubble to the container.
-          // On Windows this means a container-level listener never fires.
-          const xtermTextarea = terminalRef.current.querySelector('textarea.xterm-helper-textarea');
-          if (xtermTextarea) {
-            xtermTextarea.addEventListener('paste', handlePaste as EventListener);
-          } else {
-            terminalRef.current.addEventListener('paste', handlePaste);
-          }
+          // Attach on the container in CAPTURE phase — this fires before xterm's
+          // listener on the textarea, letting us block image pastes from reaching xterm.
+          terminalRef.current.addEventListener('paste', handlePaste, { capture: true });
 
           // Handle drag-and-drop of files onto the terminal
           const handleDragOver = (e: DragEvent) => {
@@ -991,7 +988,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             unsubscribeFontUpdate();
             inputDisposable.dispose();
             scrollDisposable.dispose();
-            terminalElement?.removeEventListener('paste', handlePaste);
+            terminalElement?.removeEventListener('paste', handlePaste, { capture: true });
           };
         }
       } catch (error) {

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -118,37 +118,44 @@ async function readClipboardImageFallback(sessionId: string): Promise<{ filePath
   const wsl = await isWSL();
 
   if (wsl) {
-    // WSL: Use PowerShell to read the Windows clipboard (saves as BMP/PNG)
-    const ps = await findPowerShell();
-    if (!ps) {
-      console.warn('[ClipboardFallback] PowerShell not found on WSL');
-      return null;
-    }
-
-    const filePath = buildFilePath();
-
-    // Convert WSL path to Windows path for PowerShell
-    let winPath: string;
-    try {
-      const { stdout } = await execFileAsync('wslpath', ['-w', filePath]);
-      winPath = stdout.trim();
-    } catch {
-      console.warn('[ClipboardFallback] wslpath failed');
-      return null;
-    }
-
-    // Escape for PowerShell single-quoted string: double any apostrophes, escape backslashes
-    const escapedPath = winPath.replace(/'/g, "''").replace(/\\/g, '\\\\');
-    const psCommand = `Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img -ne $null) { $img.Save('${escapedPath}'); Write-Output 'OK' } else { Write-Output 'NO_IMAGE' }`;
-
-    try {
-      const { stdout } = await execFileAsync(ps, ['-NoProfile', '-NonInteractive', '-Command', psCommand], { timeout: 5000 });
-      if (stdout.trim() !== 'OK') {
+    // WSL: Try Electron's clipboard.readImage() first (instant, works when
+    // WSLg clipboard sync succeeds), then fall back to PowerShell.
+    const electronImg = clipboard.readImage();
+    if (!electronImg.isEmpty()) {
+      await fs.writeFile(buildFilePath(), electronImg.toPNG());
+    } else {
+      // Electron clipboard empty — fall back to PowerShell to read Windows clipboard
+      const ps = await findPowerShell();
+      if (!ps) {
+        console.warn('[ClipboardFallback] PowerShell not found on WSL');
         return null;
       }
-    } catch (err) {
-      console.warn('[ClipboardFallback] PowerShell clipboard read failed:', err);
-      return null;
+
+      const filePath = buildFilePath();
+
+      // Convert WSL path to Windows path for PowerShell
+      let winPath: string;
+      try {
+        const { stdout } = await execFileAsync('wslpath', ['-w', filePath]);
+        winPath = stdout.trim();
+      } catch {
+        console.warn('[ClipboardFallback] wslpath failed');
+        return null;
+      }
+
+      // Escape for PowerShell single-quoted string: double any apostrophes
+      const escapedPath = winPath.replace(/'/g, "''");
+      const psCommand = `Add-Type -AssemblyName System.Windows.Forms; $img = [System.Windows.Forms.Clipboard]::GetImage(); if ($img -ne $null) { $img.Save('${escapedPath}'); Write-Output 'OK' } else { Write-Output 'NO_IMAGE' }`;
+
+      try {
+        const { stdout } = await execFileAsync(ps, ['-NoProfile', '-NonInteractive', '-Command', psCommand], { timeout: 15000 });
+        if (stdout.trim() !== 'OK') {
+          return null;
+        }
+      } catch (err) {
+        console.warn('[ClipboardFallback] PowerShell clipboard read failed:', err);
+        return null;
+      }
     }
   } else if (process.platform === 'darwin') {
     // macOS: Use Electron's clipboard.readImage()


### PR DESCRIPTION
## Summary
- Move terminal paste listener to parent container with `{ capture: true }` so it fires before xterm's own handler — prevents xterm from pasting clipboard text alongside image data
- WSL clipboard fallback: try `clipboard.readImage()` first (instant) before PowerShell
- Bump PowerShell timeout from 5s → 15s
- Remove unnecessary backslash escaping in PowerShell single-quoted strings

## Test plan
- [ ] Paste image on Windows with WSL project — should show `[Image] /path` without bare `[Image]`
- [ ] Paste text in terminal — should work normally (no regression)
- [ ] Paste image on macOS — should work as before