### PR TITLE
feat: inject PANE_PORT and PANE_WORKSPACE_PATH into session environments

### DIFF
--- a/main/src/services/panels/logPanel/logsManager.ts
+++ b/main/src/services/panels/logPanel/logsManager.ts
@@ -144,12 +144,20 @@ export class LogsManager {
     // Get enhanced shell PATH for packaged apps
     const shellPath = getShellPath();
 
+    // Compute PANE_PORT — deterministic 10-port block per session for parallel dev servers
+    let portHash = 0;
+    for (let i = 0; i < sessionId.length; i++) {
+      portHash = ((portHash << 5) - portHash) + sessionId.charCodeAt(i);
+      portHash |= 0;
+    }
+    const panePort = String(3000 + (Math.abs(portHash) % 600) * 10);
+
     // Start process with shell
     let childProcess: ChildProcess;
 
     if (wslContext) {
       childProcess = spawn('wsl.exe', ['-d', wslContext.distribution, '--', 'bash', '-c', `cd '${cwd}' && ${command}`], {
-        env: { ...process.env, PATH: shellPath }
+        env: { ...process.env, PATH: shellPath, PANE_PORT: panePort, PANE_WORKSPACE_PATH: cwd }
       });
     } else {
       childProcess = spawn(command, [], {
@@ -157,7 +165,9 @@ export class LogsManager {
         shell: true,
         env: {
           ...process.env,
-          PATH: shellPath
+          PATH: shellPath,
+          PANE_PORT: panePort,
+          PANE_WORKSPACE_PATH: cwd
         }
       });
     }

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -201,6 +201,19 @@ export class TerminalPanelManager {
     const isLinux = process.platform === 'linux';
     const enhancedPath = isLinux ? (process.env.PATH || '') : getShellPath();
 
+    /**
+     * PANE_PORT: deterministic port block per session (10 consecutive ports).
+     * Avoids port conflicts when running parallel worktree dev servers.
+     * Hash the sessionId to a port in the 3000–8990 range (600 blocks of 10).
+     * Usage in pane.json: { "scripts": { "run": "PORT=$PANE_PORT pnpm dev" } }
+     */
+    let portHash = 0;
+    for (let i = 0; i < panel.sessionId.length; i++) {
+      portHash = ((portHash << 5) - portHash) + panel.sessionId.charCodeAt(i);
+      portHash |= 0;
+    }
+    const panePort = 3000 + (Math.abs(portHash) % 600) * 10;
+
     // Create PTY process with enhanced environment
     const ptyProcess = pty.spawn(shellPath, shellArgs, {
       name: 'xterm-256color',
@@ -216,7 +229,9 @@ export class TerminalPanelManager {
         LANG: process.env.LANG || 'en_US.UTF-8',
         WORKTREE_PATH: cwd,
         PANE_SESSION_ID: panel.sessionId,
-        PANE_PANEL_ID: panel.id
+        PANE_PANEL_ID: panel.id,
+        PANE_PORT: String(panePort),
+        PANE_WORKSPACE_PATH: cwd
       }
     });
     


### PR DESCRIPTION
## Summary

- Each session gets a deterministic block of 10 ports (`$PANE_PORT` through `$PANE_PORT+9`) based on session ID hash
- Avoids port conflicts when running parallel worktree dev servers
- Also injects `$PANE_WORKSPACE_PATH` (the worktree's absolute path)
- Injected into both terminal panel PTY processes and logsManager script execution

## Usage in pane.json

```json
{
  "scripts": {
    "run": "PORT=$PANE_PORT pnpm dev"
  }
}
```

## Test plan

- [ ] Create two worktree sessions, verify `echo $PANE_PORT` shows different values
- [ ] Verify port is stable across terminal restarts for the same session
- [ ] Verify `$PANE_WORKSPACE_PATH` matches the worktree directory

Closes #111