### PR TITLE
feat: PTY activity status tracking with colored dots

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { ResumeSessionsDialog } from './components/ResumeSessionsDialog';
 import { useErrorStore } from './stores/errorStore';
 import { useSessionStore } from './stores/sessionStore';
 import { useConfigStore } from './stores/configStore';
+import { usePanelStore } from './stores/panelStore';
 import { API } from './utils/api';
 import { createVisibilityAwareInterval } from './utils/performanceUtils';
 import { ContextMenuProvider } from './contexts/ContextMenuContext';
@@ -119,6 +120,14 @@ function App() {
   
   useIPCEvents();
   const { showNotification } = useNotifications();
+
+  // Global panel activity status listener
+  useEffect(() => {
+    const unsubscribe = window.electronAPI?.events?.onPanelActivityStatus?.((data) => {
+      usePanelStore.getState().setActivityStatus(data.panelId, data.status);
+    });
+    return () => unsubscribe?.();
+  }, []);
 
   // Keyboard shortcuts
 

--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -458,8 +458,8 @@ export function ProjectSessionList({ sessionSortAscending }: ProjectSessionListP
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-1.5 min-w-0">
                       <span className={cn(
-                        "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-colors duration-300",
-                        projectActivity === 'active' ? 'bg-status-warning' : 'bg-text-muted/20'
+                        "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all duration-500",
+                        projectActivity === 'active' ? 'bg-status-warning opacity-100' : 'bg-text-muted/20 opacity-40'
                       )} />
                       <span className="text-xs font-semibold text-text-primary truncate">{project.name}</span>
                     </div>
@@ -551,8 +551,8 @@ function SessionRowContent({ session, gs, iconColor, hasDiff, adds, dels, activi
   return (
     <div className="flex items-center gap-2 min-w-0 w-full">
       <span className={cn(
-        "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-colors duration-300",
-        activityStatus === 'active' ? 'bg-status-warning' : 'bg-text-muted/20'
+        "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all duration-500",
+        activityStatus === 'active' ? 'bg-status-warning opacity-100' : 'bg-text-muted/20 opacity-40'
       )} />
       {gs?.prNumber ? (
         <GitPullRequest className={`w-3.5 h-3.5 flex-shrink-0 ${iconColor}`} />

--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -40,7 +40,8 @@ export function ProjectSessionList({ sessionSortAscending }: ProjectSessionListP
   const setActiveSession = useSessionStore(s => s.setActiveSession);
   const navigateToSessions = useNavigationStore(s => s.navigateToSessions);
   const navigateToProject = useNavigationStore(s => s.navigateToProject);
-  const panelState = usePanelStore(s => ({ panels: s.panels, activityStatus: s.activityStatus }));
+  const panelPanels = usePanelStore(s => s.panels);
+  const panelActivityStatus = usePanelStore(s => s.activityStatus);
 
   // Hotkey registration
   const register = useHotkeyStore(s => s.register);
@@ -404,8 +405,8 @@ export function ProjectSessionList({ sessionSortAscending }: ProjectSessionListP
           const projectSessions = sessionsByProject.get(project.id) || [];
 
           const projectActivity = projectSessions.some(s => {
-            const sessionPanels = panelState.panels[s.id] || [];
-            return sessionPanels.some(p => panelState.activityStatus[p.id] === 'active');
+            const sessionPanels = panelPanels[s.id] || [];
+            return sessionPanels.some(p => panelActivityStatus[p.id] === 'active');
           }) ? 'active' : 'idle';
 
           const projectMenuItems: DropdownItem[] = [
@@ -458,7 +459,7 @@ export function ProjectSessionList({ sessionSortAscending }: ProjectSessionListP
                     <div className="flex items-center gap-1.5 min-w-0">
                       <span className={cn(
                         "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-colors duration-300",
-                        projectActivity === 'active' ? 'bg-status-warning' : 'bg-status-success'
+                        projectActivity === 'active' ? 'bg-status-warning' : 'bg-text-muted/20'
                       )} />
                       <span className="text-xs font-semibold text-text-primary truncate">{project.name}</span>
                     </div>
@@ -551,7 +552,7 @@ function SessionRowContent({ session, gs, iconColor, hasDiff, adds, dels, activi
     <div className="flex items-center gap-2 min-w-0 w-full">
       <span className={cn(
         "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-colors duration-300",
-        activityStatus === 'active' ? 'bg-status-warning' : 'bg-status-success'
+        activityStatus === 'active' ? 'bg-status-warning' : 'bg-text-muted/20'
       )} />
       {gs?.prNumber ? (
         <GitPullRequest className={`w-3.5 h-3.5 flex-shrink-0 ${iconColor}`} />

--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -458,8 +458,10 @@ export function ProjectSessionList({ sessionSortAscending }: ProjectSessionListP
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-1.5 min-w-0">
                       <span className={cn(
-                        "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all duration-500",
-                        projectActivity === 'active' ? 'bg-status-warning opacity-100' : 'bg-text-muted/20 opacity-40'
+                        "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all",
+                        projectActivity === 'active'
+                          ? 'bg-status-warning opacity-100 duration-150'
+                          : 'bg-text-muted/20 opacity-40 duration-[3s]'
                       )} />
                       <span className="text-xs font-semibold text-text-primary truncate">{project.name}</span>
                     </div>
@@ -551,8 +553,10 @@ function SessionRowContent({ session, gs, iconColor, hasDiff, adds, dels, activi
   return (
     <div className="flex items-center gap-2 min-w-0 w-full">
       <span className={cn(
-        "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all duration-500",
-        activityStatus === 'active' ? 'bg-status-warning opacity-100' : 'bg-text-muted/20 opacity-40'
+        "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all",
+        activityStatus === 'active'
+          ? 'bg-status-warning opacity-100 duration-150'
+          : 'bg-text-muted/20 opacity-40 duration-[3s]'
       )} />
       {gs?.prNumber ? (
         <GitPullRequest className={`w-3.5 h-3.5 flex-shrink-0 ${iconColor}`} />

--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -14,6 +14,7 @@ import { cycleIndex } from '../utils/arrayUtils';
 import { cn } from '../utils/cn';
 import type { Session, GitStatus } from '../types/session';
 import type { Project } from '../types/project';
+import { usePanelStore } from '../stores/panelStore';
 
 
 
@@ -39,6 +40,7 @@ export function ProjectSessionList({ sessionSortAscending }: ProjectSessionListP
   const setActiveSession = useSessionStore(s => s.setActiveSession);
   const navigateToSessions = useNavigationStore(s => s.navigateToSessions);
   const navigateToProject = useNavigationStore(s => s.navigateToProject);
+  const panelState = usePanelStore(s => ({ panels: s.panels, activityStatus: s.activityStatus }));
 
   // Hotkey registration
   const register = useHotkeyStore(s => s.register);
@@ -401,6 +403,11 @@ export function ProjectSessionList({ sessionSortAscending }: ProjectSessionListP
           const isExpanded = expandedProjects.has(project.id);
           const projectSessions = sessionsByProject.get(project.id) || [];
 
+          const projectActivity = projectSessions.some(s => {
+            const sessionPanels = panelState.panels[s.id] || [];
+            return sessionPanels.some(p => panelState.activityStatus[p.id] === 'active');
+          }) ? 'active' : 'idle';
+
           const projectMenuItems: DropdownItem[] = [
             {
               id: 'main-workspace',
@@ -448,7 +455,13 @@ export function ProjectSessionList({ sessionSortAscending }: ProjectSessionListP
               >
                 <Tooltip content={<span className="text-[10px] text-text-tertiary font-mono break-all">{project.path}</span>} side="right">
                   <div className="flex-1 min-w-0">
-                    <span className="text-xs font-semibold text-text-primary truncate block">{project.name}</span>
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <span className={cn(
+                        "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-colors duration-300",
+                        projectActivity === 'active' ? 'bg-status-warning' : 'bg-status-success'
+                      )} />
+                      <span className="text-xs font-semibold text-text-primary truncate">{project.name}</span>
+                    </div>
                   </div>
                 </Tooltip>
                 <div
@@ -525,16 +538,21 @@ export function ProjectSessionList({ sessionSortAscending }: ProjectSessionListP
 
 // --- Session row button content ---
 
-function SessionRowContent({ session, gs, iconColor, hasDiff, adds, dels }: {
+function SessionRowContent({ session, gs, iconColor, hasDiff, adds, dels, activityStatus }: {
   session: Session;
   gs: GitStatus | undefined;
   iconColor: string;
   hasDiff: boolean;
   adds: number;
   dels: number;
+  activityStatus: 'active' | 'idle';
 }) {
   return (
     <div className="flex items-center gap-2 min-w-0 w-full">
+      <span className={cn(
+        "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-colors duration-300",
+        activityStatus === 'active' ? 'bg-status-warning' : 'bg-status-success'
+      )} />
       {gs?.prNumber ? (
         <GitPullRequest className={`w-3.5 h-3.5 flex-shrink-0 ${iconColor}`} />
       ) : (
@@ -575,6 +593,11 @@ function SessionRow({
   onArchive,
 }: SessionRowProps) {
   const [localGitStatus, setLocalGitStatus] = useState<GitStatus | undefined>(session.gitStatus);
+
+  const sessionActivity = usePanelStore(s => {
+    const sessionPanels = s.panels[session.id] || [];
+    return sessionPanels.some(p => s.activityStatus[p.id] === 'active') ? 'active' : 'idle';
+  });
 
   // Fetch git status if not available
   useEffect(() => {
@@ -663,6 +686,7 @@ function SessionRow({
           hasDiff={hasDiff}
           adds={adds}
           dels={dels}
+          activityStatus={sessionActivity}
         />
       </Tooltip>
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -210,7 +210,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
                     const isActive = session.id === activeSessionId;
                     const sessionPanels = panelsBySession[session.id] || [];
                     const isSessionActive = sessionPanels.some(p => activityStatus[p.id] === 'active');
-                    const statusColor = isSessionActive ? 'bg-status-warning' : 'bg-status-success';
+                    const statusColor = isSessionActive ? 'bg-status-warning' : 'bg-text-muted/20';
                     const isAnimated = isSessionActive;
                     return (
                       <Tooltip key={session.id} content={<SessionDetailTooltip session={session} />} side="right">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -16,6 +16,7 @@ import { Dropdown } from './ui/Dropdown';
 import type { DropdownItem } from './ui/Dropdown';
 import { useSessionStore } from '../stores/sessionStore';
 import { useNavigationStore } from '../stores/navigationStore';
+import { usePanelStore } from '../stores/panelStore';
 import { API } from '../utils/api';
 import type { Project } from '../types/project';
 
@@ -124,6 +125,8 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
   const sessions = useSessionStore((state) => state.sessions);
   const activeSessionId = useSessionStore((state) => state.activeSessionId);
   const setActiveSession = useSessionStore((state) => state.setActiveSession);
+  const activityStatus = usePanelStore(s => s.activityStatus);
+  const panelsBySession = usePanelStore(s => s.panels);
 
   // State for collapsed sidebar
   const [projects, setProjects] = useState<Project[]>([]);
@@ -205,14 +208,10 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
                   {/* Session status badges — grouped under this project */}
                   {projectSessions.map((session) => {
                     const isActive = session.id === activeSessionId;
-                    const statusColor = session.status === 'running' || session.status === 'initializing'
-                      ? 'bg-status-success'
-                      : session.status === 'waiting'
-                      ? 'bg-status-warning'
-                      : session.status === 'error'
-                      ? 'bg-status-error'
-                      : 'bg-status-neutral';
-                    const isAnimated = session.status === 'running' || session.status === 'initializing' || session.status === 'waiting';
+                    const sessionPanels = panelsBySession[session.id] || [];
+                    const isSessionActive = sessionPanels.some(p => activityStatus[p.id] === 'active');
+                    const statusColor = isSessionActive ? 'bg-status-warning' : 'bg-status-success';
+                    const isAnimated = isSessionActive;
                     return (
                       <Tooltip key={session.id} content={<SessionDetailTooltip session={session} />} side="right">
                         <button

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -210,7 +210,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
                     const isActive = session.id === activeSessionId;
                     const sessionPanels = panelsBySession[session.id] || [];
                     const isSessionActive = sessionPanels.some(p => activityStatus[p.id] === 'active');
-                    const statusColor = isSessionActive ? 'bg-status-warning opacity-100' : 'bg-text-muted/20 opacity-40';
+                    const statusColor = isSessionActive ? 'bg-status-warning opacity-100 duration-150' : 'bg-text-muted/20 opacity-40 duration-[3s]';
                     const isAnimated = isSessionActive;
                     return (
                       <Tooltip key={session.id} content={<SessionDetailTooltip session={session} />} side="right">
@@ -225,7 +225,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
                            * TODO: Evolve into richer interactive badges with session identity
                            * (e.g., initials, mini name) and better click-to-navigate affordance.
                            */}
-                          <div className={`w-2.5 h-2.5 rounded-full transition-all duration-500 ${statusColor} ${isAnimated ? 'animate-pulse' : ''}`} />
+                          <div className={`w-2.5 h-2.5 rounded-full transition-all ${statusColor} ${isAnimated ? 'animate-pulse' : ''}`} />
                         </button>
                       </Tooltip>
                     );

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -210,7 +210,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
                     const isActive = session.id === activeSessionId;
                     const sessionPanels = panelsBySession[session.id] || [];
                     const isSessionActive = sessionPanels.some(p => activityStatus[p.id] === 'active');
-                    const statusColor = isSessionActive ? 'bg-status-warning' : 'bg-text-muted/20';
+                    const statusColor = isSessionActive ? 'bg-status-warning opacity-100' : 'bg-text-muted/20 opacity-40';
                     const isAnimated = isSessionActive;
                     return (
                       <Tooltip key={session.id} content={<SessionDetailTooltip session={session} />} side="right">
@@ -225,7 +225,7 @@ export function Sidebar({ onAboutClick, onSettingsClick, isSettingsOpen, onSetti
                            * TODO: Evolve into richer interactive badges with session identity
                            * (e.g., initials, mini name) and better click-to-navigate affordance.
                            */}
-                          <div className={`w-2.5 h-2.5 rounded-full ${statusColor} ${isAnimated ? 'animate-pulse' : ''}`} />
+                          <div className={`w-2.5 h-2.5 rounded-full transition-all duration-500 ${statusColor} ${isAnimated ? 'animate-pulse' : ''}`} />
                         </button>
                       </Tooltip>
                     );

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -13,6 +13,7 @@ import { Tooltip } from '../ui/Tooltip';
 import { Kbd } from '../ui/Kbd';
 import { useResourceMonitor } from '../../hooks/useResourceMonitor';
 import { ClaudeIcon, OpenAIIcon, CLI_BRAND_ICONS, getCliBrandIcon } from '../ui/BrandIcons';
+import { usePanelStore } from '../../stores/panelStore';
 import type { WorktreeFileSyncEntry } from '../../../../shared/types/worktreeFileSync';
 
 function formatMemory(mb: number): string {
@@ -91,6 +92,8 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
   const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(['pane-app']));
   const { snapshot, startActive, stopActive, refresh } = useResourceMonitor();
   const [popoverStyle, setPopoverStyle] = useState<React.CSSProperties>({});
+
+  const getPanelActivityStatus = usePanelStore(s => s.getPanelActivityStatus);
 
   const customCommands = config?.customCommands ?? [];
   const hotkeys = useHotkeyStore((s) => s.hotkeys);
@@ -578,6 +581,10 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
                 />
               ) : (
                 <span className="inline-flex items-center justify-center gap-2 min-w-0">
+                  <span className={cn(
+                    "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-colors duration-300",
+                    getPanelActivityStatus(panel.id) === 'active' ? 'bg-status-warning' : 'bg-status-success'
+                  )} />
                   {getPanelIcon(panel.type, panel)}
                   <span>{displayTitle}</span>
                 </span>

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -583,8 +583,10 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
                 <span className="inline-flex items-center justify-center gap-2 min-w-0">
                   {panel.type === 'terminal' && (
                     <span className={cn(
-                      "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all duration-500",
-                      getPanelActivityStatus(panel.id) === 'active' ? 'bg-status-warning opacity-100' : 'bg-text-muted/20 opacity-40'
+                      "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all",
+                      getPanelActivityStatus(panel.id) === 'active'
+                        ? 'bg-status-warning opacity-100 duration-150'
+                        : 'bg-text-muted/20 opacity-40 duration-[3s]'
                     )} />
                   )}
                   {getPanelIcon(panel.type, panel)}

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -583,8 +583,8 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
                 <span className="inline-flex items-center justify-center gap-2 min-w-0">
                   {panel.type === 'terminal' && (
                     <span className={cn(
-                      "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-colors duration-300",
-                      getPanelActivityStatus(panel.id) === 'active' ? 'bg-status-warning' : 'bg-text-muted/20'
+                      "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all duration-500",
+                      getPanelActivityStatus(panel.id) === 'active' ? 'bg-status-warning opacity-100' : 'bg-text-muted/20 opacity-40'
                     )} />
                   )}
                   {getPanelIcon(panel.type, panel)}

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -581,10 +581,12 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
                 />
               ) : (
                 <span className="inline-flex items-center justify-center gap-2 min-w-0">
-                  <span className={cn(
-                    "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-colors duration-300",
-                    getPanelActivityStatus(panel.id) === 'active' ? 'bg-status-warning' : 'bg-status-success'
-                  )} />
+                  {panel.type === 'terminal' && (
+                    <span className={cn(
+                      "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-colors duration-300",
+                      getPanelActivityStatus(panel.id) === 'active' ? 'bg-status-warning' : 'bg-text-muted/20'
+                    )} />
+                  )}
                   {getPanelIcon(panel.type, panel)}
                   <span>{displayTitle}</span>
                 </span>

--- a/frontend/src/stores/panelStore.ts
+++ b/frontend/src/stores/panelStore.ts
@@ -8,6 +8,7 @@ export const usePanelStore = create<PanelStore>()(
   immer((set, get) => ({
     panels: {},
     activePanels: {},
+    activityStatus: {},
 
     // Pure synchronous state updates
     setPanels: (sessionId, panels) => {
@@ -46,6 +47,7 @@ export const usePanelStore = create<PanelStore>()(
         if (state.activePanels[sessionId] === panelId) {
           delete state.activePanels[sessionId];
         }
+        delete state.activityStatus[panelId];
       });
     },
 
@@ -61,11 +63,29 @@ export const usePanelStore = create<PanelStore>()(
       });
     },
 
+    setActivityStatus: (panelId, status) => {
+      set((state) => {
+        state.activityStatus[panelId] = status;
+      });
+    },
+
+    clearActivityStatus: (panelId) => {
+      set((state) => {
+        delete state.activityStatus[panelId];
+      });
+    },
+
     // Getters remain the same
     getSessionPanels: (sessionId) => get().panels[sessionId] || [],
     getActivePanel: (sessionId) => {
       const panels = get().panels[sessionId] || [];
       return panels.find(p => p.id === get().activePanels[sessionId]);
-    }
+    },
+    getPanelActivityStatus: (panelId) => get().activityStatus[panelId] || 'idle',
+    getSessionActivityStatus: (sessionId) => {
+      const sessionPanels = get().panels[sessionId] || [];
+      const actStatus = get().activityStatus;
+      return sessionPanels.some((p) => actStatus[p.id] === 'active') ? 'active' : 'idle';
+    },
   }))
 );

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -268,6 +268,7 @@ interface ElectronAPI {
     // Panel events
     onPanelCreated: (callback: (panel: ToolPanel) => void) => () => void;
     onPanelUpdated: (callback: (panel: ToolPanel) => void) => () => void;
+    onPanelActivityStatus: (callback: (data: { panelId: string; sessionId: string; status: 'active' | 'idle' }) => void) => () => void;
     onPanelPromptAdded: (callback: (data: { panelId: string; content: string }) => void) => () => void;
     onPanelResponseAdded: (callback: (data: { panelId: string; content: string }) => void) => () => void;
     

--- a/frontend/src/types/panelStore.ts
+++ b/frontend/src/types/panelStore.ts
@@ -4,6 +4,7 @@ export interface PanelStore {
   // State (using plain objects instead of Maps for React reactivity)
   panels: Record<string, ToolPanel[]>;        // sessionId -> panels
   activePanels: Record<string, string>;       // sessionId -> active panelId
+  activityStatus: Record<string, 'active' | 'idle'>; // panelId -> status
 
   // Synchronous state update actions
   setPanels: (sessionId: string, panels: ToolPanel[]) => void;
@@ -11,8 +12,12 @@ export interface PanelStore {
   addPanel: (panel: ToolPanel) => void;
   removePanel: (sessionId: string, panelId: string) => void;
   updatePanelState: (panel: ToolPanel) => void;
+  setActivityStatus: (panelId: string, status: 'active' | 'idle') => void;
+  clearActivityStatus: (panelId: string) => void;
 
   // Getters
   getSessionPanels: (sessionId: string) => ToolPanel[];
   getActivePanel: (sessionId: string) => ToolPanel | undefined;
+  getPanelActivityStatus: (panelId: string) => 'active' | 'idle';
+  getSessionActivityStatus: (sessionId: string) => 'active' | 'idle';
 }

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -545,6 +545,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('panel:updated', wrappedCallback);
       return () => ipcRenderer.removeListener('panel:updated', wrappedCallback);
     },
+    onPanelActivityStatus: (callback: (data: { panelId: string; sessionId: string; status: 'active' | 'idle' }) => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent, data: { panelId: string; sessionId: string; status: 'active' | 'idle' }) => callback(data);
+      ipcRenderer.on('panel:activityStatus', wrappedCallback);
+      return () => ipcRenderer.removeListener('panel:activityStatus', wrappedCallback);
+    },
     
     // Folder events
     onFolderCreated: (callback: (folder: Folder) => void) => {

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -16,7 +16,7 @@ const OUTPUT_BATCH_INTERVAL = 32; // ms (~30fps) — wider window reduces TUI fl
 const OUTPUT_BATCH_SIZE = 131072; // 128KB — timer-based flush preferred; size trigger is safety net
 const PAUSE_SAFETY_TIMEOUT = 5_000; // 5s — auto-resume PTY if no acks arrive (prevents permanent stall)
 const MAX_CONCURRENT_SPAWNS = 3;
-const IDLE_THRESHOLD_MS = 3_000; // 3s — mark panel idle after no PTY output
+const IDLE_THRESHOLD_MS = 5_000; // 5s — mark panel idle after no PTY output
 
 interface TerminalProcess {
   pty: pty.IPty;

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -16,6 +16,7 @@ const OUTPUT_BATCH_INTERVAL = 32; // ms (~30fps) — wider window reduces TUI fl
 const OUTPUT_BATCH_SIZE = 131072; // 128KB — timer-based flush preferred; size trigger is safety net
 const PAUSE_SAFETY_TIMEOUT = 5_000; // 5s — auto-resume PTY if no acks arrive (prevents permanent stall)
 const MAX_CONCURRENT_SPAWNS = 3;
+const IDLE_THRESHOLD_MS = 4_000; // 4s — mark panel idle after no PTY output
 
 interface TerminalProcess {
   pty: pty.IPty;
@@ -35,6 +36,8 @@ interface TerminalProcess {
   outputFlushTimer: ReturnType<typeof setTimeout> | null;
   // Alternate screen buffer tracking — universal TUI detection signal
   isAlternateScreen: boolean;
+  activityStatus: 'active' | 'idle';
+  idleTimer: ReturnType<typeof setTimeout> | null;
 }
 
 export class TerminalPanelManager {
@@ -250,7 +253,9 @@ export class TerminalPanelManager {
       pauseSafetyTimer: null,
       outputBuffer: '',
       outputFlushTimer: null,
-      isAlternateScreen: false
+      isAlternateScreen: false,
+      activityStatus: 'idle',
+      idleTimer: null
     };
     
     // Store in map
@@ -406,6 +411,18 @@ export class TerminalPanelManager {
       // Update last activity
       terminal.lastActivity = new Date();
 
+      // Activity status transition: mark active on first byte after idle
+      if (terminal.activityStatus !== 'active') {
+        terminal.activityStatus = 'active';
+        this.emitActivityStatus(terminal);
+      }
+      if (terminal.idleTimer) clearTimeout(terminal.idleTimer);
+      terminal.idleTimer = setTimeout(() => {
+        terminal.activityStatus = 'idle';
+        terminal.idleTimer = null;
+        this.emitActivityStatus(terminal);
+      }, IDLE_THRESHOLD_MS);
+
       // Detect alternate screen buffer enter/exit for universal TUI detection
       // (works on WSL where pty.process reports wsl.exe instead of the Linux foreground app)
       // \x1b[?1049h = enter alternate screen, \x1b[?1049l = leave alternate screen
@@ -480,6 +497,16 @@ export class TerminalPanelManager {
     
     // Handle terminal exit
     terminal.pty.onExit((exitCode: { exitCode: number; signal?: number }) => {
+      // Clear idle timer and mark as idle on exit
+      if (terminal.idleTimer) {
+        clearTimeout(terminal.idleTimer);
+        terminal.idleTimer = null;
+      }
+      if (terminal.activityStatus !== 'idle') {
+        terminal.activityStatus = 'idle';
+        this.emitActivityStatus(terminal);
+      }
+
       // Emit exit event
       panelManager.emitPanelEvent(
         terminal.panelId,
@@ -695,6 +722,16 @@ export class TerminalPanelManager {
     };
   }
   
+  private emitActivityStatus(terminal: TerminalProcess): void {
+    if (mainWindow) {
+      mainWindow.webContents.send('panel:activityStatus', {
+        panelId: terminal.panelId,
+        sessionId: terminal.sessionId,
+        status: terminal.activityStatus
+      });
+    }
+  }
+
   destroyTerminal(panelId: string): void {
     const terminal = this.terminals.get(panelId);
     if (!terminal) {
@@ -712,6 +749,10 @@ export class TerminalPanelManager {
     if (terminal.pauseSafetyTimer) {
       clearTimeout(terminal.pauseSafetyTimer);
       terminal.pauseSafetyTimer = null;
+    }
+    if (terminal.idleTimer) {
+      clearTimeout(terminal.idleTimer);
+      terminal.idleTimer = null;
     }
     this.flushOutputBuffer(terminal);
 
@@ -847,6 +888,10 @@ export class TerminalPanelManager {
         if (terminal.pauseSafetyTimer) {
           clearTimeout(terminal.pauseSafetyTimer);
           terminal.pauseSafetyTimer = null;
+        }
+        if (terminal.idleTimer) {
+          clearTimeout(terminal.idleTimer);
+          terminal.idleTimer = null;
         }
         this.flushOutputBuffer(terminal);
 

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -16,7 +16,7 @@ const OUTPUT_BATCH_INTERVAL = 32; // ms (~30fps) — wider window reduces TUI fl
 const OUTPUT_BATCH_SIZE = 131072; // 128KB — timer-based flush preferred; size trigger is safety net
 const PAUSE_SAFETY_TIMEOUT = 5_000; // 5s — auto-resume PTY if no acks arrive (prevents permanent stall)
 const MAX_CONCURRENT_SPAWNS = 3;
-const IDLE_THRESHOLD_MS = 1_000; // 1s — mark panel idle after no PTY output
+const IDLE_THRESHOLD_MS = 3_000; // 3s — mark panel idle after no PTY output
 
 interface TerminalProcess {
   pty: pty.IPty;

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -16,7 +16,7 @@ const OUTPUT_BATCH_INTERVAL = 32; // ms (~30fps) — wider window reduces TUI fl
 const OUTPUT_BATCH_SIZE = 131072; // 128KB — timer-based flush preferred; size trigger is safety net
 const PAUSE_SAFETY_TIMEOUT = 5_000; // 5s — auto-resume PTY if no acks arrive (prevents permanent stall)
 const MAX_CONCURRENT_SPAWNS = 3;
-const IDLE_THRESHOLD_MS = 4_000; // 4s — mark panel idle after no PTY output
+const IDLE_THRESHOLD_MS = 1_000; // 1s — mark panel idle after no PTY output
 
 interface TerminalProcess {
   pty: pty.IPty;


### PR DESCRIPTION
## Summary
- Adds agent-agnostic PTY idle detection — monitors byte output to determine when terminal agents finish working
- After 4 seconds of silence, panels transition from active (yellow dot) to idle (green dot)
- Status dots visible at 3 levels: panel tabs, session rows, and project headers in the sidebar
- Zero database writes — purely ephemeral runtime state via lightweight IPC events (~2 per agent turn)

## Implementation
- **Backend**: Debounced idle timer in `TerminalPanelManager.onData()` — single chokepoint for all PTY output
- **IPC bridge**: New `panel:activityStatus` event through preload
- **Frontend store**: `activityStatus` map in `panelStore` with derived session/project-level selectors
- **UI**: `w-1.5 h-1.5` colored dots with `transition-colors duration-300` for smooth yellow↔green transitions

## Test plan
- [ ] Start a Claude/Codex session — panel tab dot should turn yellow when agent is actively outputting
- [ ] Wait for agent to finish — dot should turn green ~4s after output stops
- [ ] Check session row in sidebar — should aggregate panel activity (yellow if any panel active)
- [ ] Check project header — should aggregate session activity
- [ ] Check collapsed sidebar — dots should reflect activity status
- [ ] Kill a session — dot should transition to green (idle on exit)
- [ ] Multiple concurrent sessions — each tracks independently