### PR TITLE
fix: restore textarea paste listener and blue activity dots

### DIFF
--- a/frontend/src/components/ProjectSessionList.tsx
+++ b/frontend/src/components/ProjectSessionList.tsx
@@ -460,7 +460,7 @@ export function ProjectSessionList({ sessionSortAscending }: ProjectSessionListP
                       <span className={cn(
                         "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all",
                         projectActivity === 'active'
-                          ? 'bg-status-warning opacity-100 duration-150'
+                          ? 'bg-status-info opacity-100 duration-150'
                           : 'bg-text-muted/20 opacity-40 duration-[3s]'
                       )} />
                       <span className="text-xs font-semibold text-text-primary truncate">{project.name}</span>
@@ -555,7 +555,7 @@ function SessionRowContent({ session, gs, iconColor, hasDiff, adds, dels, activi
       <span className={cn(
         "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all",
         activityStatus === 'active'
-          ? 'bg-status-warning opacity-100 duration-150'
+          ? 'bg-status-info opacity-100 duration-150'
           : 'bg-text-muted/20 opacity-40 duration-[3s]'
       )} />
       {gs?.prNumber ? (

--- a/frontend/src/components/panels/PanelTabBar.tsx
+++ b/frontend/src/components/panels/PanelTabBar.tsx
@@ -585,7 +585,7 @@ export const PanelTabBar: React.FC<PanelTabBarProps> = memo(({
                     <span className={cn(
                       "w-1.5 h-1.5 rounded-full flex-shrink-0 transition-all",
                       getPanelActivityStatus(panel.id) === 'active'
-                        ? 'bg-status-warning opacity-100 duration-150'
+                        ? 'bg-status-info opacity-100 duration-150'
                         : 'bg-text-muted/20 opacity-40 duration-[3s]'
                     )} />
                   )}

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -593,11 +593,14 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           }
 
           // Handle paste events (Ctrl+V, voice transcription, external text injection)
-          // Attached on the container in CAPTURE phase so we fire BEFORE xterm's own
-          // paste handler on the textarea.  When an image is detected we call
-          // stopPropagation() so xterm never sees the event — this prevents xterm from
-          // also pasting whatever text/plain happens to be in the clipboard alongside
-          // the image, which caused bare "[Image]" (no path) to appear on Windows/WSL.
+          // Attached on xterm's internal textarea so we fire alongside xterm's own handler.
+          // When an image is detected we call stopPropagation() so xterm's container-level
+          // bubble handler never fires — this prevents xterm from also pasting whatever
+          // text/plain happens to be in the clipboard alongside the image, which caused
+          // bare "[Image]" (no path) to appear on Windows. The textarea attachment (vs
+          // container capture) is required for WSL: on WSL the clipboard data is not
+          // bridged to browser ClipboardEvents, so we need xterm's own paste path to
+          // remain reachable for text paste when our image fallback finds nothing.
           const handlePaste = (e: ClipboardEvent) => {
             // Check for images in browser clipboard first (works on native Windows/macOS)
             const items = e.clipboardData?.items;
@@ -654,7 +657,6 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
               // Only attempt fallback if there's no text being pasted,
               // or if text is empty (user likely intended to paste an image)
               if (!text) {
-                e.stopPropagation();
                 e.preventDefault();
                 (async () => {
                   if (disposed || !terminal) return;
@@ -676,9 +678,20 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
               // Regular text paste — let event propagate to xterm's handler.
             }
           };
-          // Attach on the container in CAPTURE phase — this fires before xterm's
-          // listener on the textarea, letting us block image pastes from reaching xterm.
-          terminalRef.current.addEventListener('paste', handlePaste, { capture: true });
+          // Attach on xterm's internal textarea — xterm calls stopPropagation() on paste
+          // events when they bubble to the container, so a container-level listener never
+          // fires on Windows. The textarea is the actual paste target, so our handler runs
+          // alongside xterm's own listener (registration order: xterm first, then ours).
+          // For images we call stopPropagation() to block xterm's container bubble handler
+          // from also pasting clipboard text/plain. For text and the system-clipboard
+          // fallback we do NOT stopPropagation so xterm can rescue the paste if needed
+          // (critical on WSL where clipboardData may be empty).
+          const xtermTextarea = terminalRef.current.querySelector('textarea.xterm-helper-textarea');
+          if (xtermTextarea) {
+            xtermTextarea.addEventListener('paste', handlePaste as EventListener);
+          } else {
+            terminalRef.current.addEventListener('paste', handlePaste);
+          }
 
           // Handle drag-and-drop of files onto the terminal
           const handleDragOver = (e: DragEvent) => {
@@ -989,7 +1002,8 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             unsubscribeFontUpdate();
             inputDisposable.dispose();
             scrollDisposable.dispose();
-            terminalElement?.removeEventListener('paste', handlePaste, { capture: true });
+            const pasteTarget = terminalElement?.querySelector('textarea.xterm-helper-textarea') ?? terminalElement;
+            pasteTarget?.removeEventListener('paste', handlePaste as EventListener);
           };
         }
       } catch (error) {


### PR DESCRIPTION
## Summary
- Restores xterm textarea paste listener (reverts #104's container+capture approach) to fix image/file paste on WSL — the capture-phase approach cut xterm out of the event chain, breaking the system clipboard fallback and causing bare `[Image]` without path
- Removes `e.stopPropagation()` from the system clipboard fallback branch so xterm can rescue text paste when `clipboardData` is empty (WSL)
- Changes PTY activity dots from yellow (`bg-status-warning`) to blue (`bg-status-info`) across panel tabs, session rows, and project headers

## Test plan
- [ ] Ctrl+V with image in Windows clipboard pastes `[Image] /path` in WSL terminal
- [ ] Ctrl+V with text pastes text correctly in WSL terminal
- [ ] Image paste still works on native Windows (no double-paste / bare `[Image]`)
- [ ] Drag-and-drop files onto terminal still works
- [ ] Activity dots appear blue when terminal is active