### PR TITLE
docs: use "Add tabs" in Usage step 3 for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ irm https://runpane.com/install.ps1 | iex
 
 1. **Open Pane** and create or select a project (any git repository)
 2. **Create a pane** — enter a prompt and pick your agent
-3. **Add panels** — launch a Claude terminal, Codex terminal, diff viewer, file explorer, or any CLI tool
+3. **Add tabs** — launch a Claude terminal, Codex terminal, diff viewer, file explorer, or any CLI tool
 4. **Work in parallel** — create multiple panes for different approaches
 5. **Review diffs** — see what changed with the built-in diff viewer
 6. **Ship** — commit, rebase, and merge from keyboard shortcuts


### PR DESCRIPTION
## Summary
Aligns Usage step 3 ("Add panels") with the How It Works wording ("panes and tabs"). One-word fix.

## Test plan
- [ ] Render on GitHub and confirm Usage step 3 reads "Add tabs"