### PR TITLE
fix: unblock vim and interactive TUIs in packaged builds

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,6 +7,14 @@ export default defineConfig({
         strictPort: true
     },
     base: './',
+    // Workaround for @xterm/xterm 6.0 double-minification bug (issue #103):
+    // xterm ships pre-minified ESM; Vite's esbuild re-minify pass renames the
+    // `ansi` parameter in InputHandler.requestMode but leaves a closure capture
+    // pointing at the old name, throwing `ReferenceError: i is not defined`
+    // when TUI apps (vim, opencode, etc.) trigger a DCS mode request.
+    esbuild: {
+        minifyIdentifiers: false
+    },
     build: {
         // Ensure assets are copied and paths are relative
         assetsDir: 'assets',

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
     strictPort: true
   },
   base: './',
+  // Workaround for @xterm/xterm 6.0 double-minification bug (issue #103):
+  // xterm ships pre-minified ESM; Vite's esbuild re-minify pass renames the
+  // `ansi` parameter in InputHandler.requestMode but leaves a closure capture
+  // pointing at the old name, throwing `ReferenceError: i is not defined`
+  // when TUI apps (vim, opencode, etc.) trigger a DCS mode request.
+  esbuild: {
+    minifyIdentifiers: false
+  },
   build: {
     // Ensure assets are copied and paths are relative
     assetsDir: 'assets',


### PR DESCRIPTION
## Summary
- `@xterm/xterm@6.0.0` ships pre-minified ESM. Vite's default esbuild re-minify pass renames the `ansi` parameter inside `InputHandler.requestMode` but leaves a closure that still references the old name, throwing `ReferenceError: i is not defined` on the first DCS mode request.
- Only affects packaged builds — dev mode skips identifier minification, which is why `pnpm electron-dev` never reproduced it.
- Fix: disable `esbuild.minifyIdentifiers` in `frontend/vite.config.{ts,js}`. Keeps whitespace/syntax compression, drops only the pass that causes the double-minification scope bug.

## Root cause detail
Reading xterm's published `xterm.mjs`, `requestMode(e, i)` contains an arrow function that captures `i`:

\`\`\`js
requestMode(e, i) {
  const p = (A, R) => (a.triggerDataEvent(\`\${b.ESC}[\${i?"":"?"}\${A};\${R}\$y\`), !0)
  ...
}
\`\`\`

When Vite's esbuild pass re-minifies this already-minified code, it re-renames the parameter but mishandles the closure reference — the capture ends up pointing at an identifier that no longer exists in scope. Disabling identifier mangling keeps the reference consistent.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm build:frontend` — succeeds, no dramatic size regression
- [ ] Run packaged build, open a terminal panel, run `vim` — verify interactive mode works without `ReferenceError`
- [ ] Run `opencode` or another TUI as a second sanity check

Fixes #103