### PR TITLE
fix: propagate injected env vars into WSL terminals via WSLENV

### DIFF
--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import { getShellPath } from '../utils/shellPath';
 import { ShellDetector } from '../utils/shellDetector';
 import type { AnalyticsManager } from './analyticsManager';
-import { getWSLShellSpawn, WSLContext } from '../utils/wslUtils';
+import { getWSLShellSpawn, buildWSLENV, WSLContext } from '../utils/wslUtils';
 import { GIT_ATTRIBUTION_ENV } from '../utils/attribution';
 
 const HIGH_WATERMARK = 100_000; // 100KB — pause PTY when pending exceeds this
@@ -219,6 +219,29 @@ export class TerminalPanelManager {
     }
     const panePort = 3000 + (Math.abs(portHash) % 600) * 10;
 
+    /**
+     * When spawning into WSL, pty.spawn's `env` sets variables on the wsl.exe
+     * Windows process, which does NOT propagate them to the bash shell inside
+     * the distro. WSLENV is Microsoft's opt-in mechanism: listing a var name
+     * here tells WSL to copy that var's value from the Windows env into the
+     * Linux env at shell startup. Without this, GIT_COMMITTER_* (and every
+     * PANE_* var) silently disappear inside WSL terminals.
+     */
+    const isWSL = !!wslContext && process.platform === 'win32';
+    const wslEnvVars = isWSL
+      ? {
+          WSLENV: buildWSLENV([
+            'GIT_COMMITTER_NAME',
+            'GIT_COMMITTER_EMAIL',
+            'PANE_PORT',
+            'PANE_SESSION_ID',
+            'PANE_PANEL_ID',
+            'WORKTREE_PATH',
+            'PANE_WORKSPACE_PATH',
+          ]),
+        }
+      : {};
+
     // Create PTY process with enhanced environment
     const ptyProcess = pty.spawn(shellPath, shellArgs, {
       name: 'xterm-256color',
@@ -236,7 +259,8 @@ export class TerminalPanelManager {
         PANE_SESSION_ID: panel.sessionId,
         PANE_PANEL_ID: panel.id,
         PANE_PORT: String(panePort),
-        PANE_WORKSPACE_PATH: cwd
+        PANE_WORKSPACE_PATH: cwd,
+        ...wslEnvVars,
       }
     });
     

--- a/main/src/utils/wslUtils.ts
+++ b/main/src/utils/wslUtils.ts
@@ -134,6 +134,26 @@ export function getWSLExecArgs(command: string, distro: string, cwd?: string, ex
 }
 
 /**
+ * Build a WSLENV value that tells WSL to propagate the given Windows env var
+ * names into the Linux environment of child shells.
+ *
+ * Background: env vars passed to `pty.spawn('wsl.exe', ..., {env})` are set on
+ * the wsl.exe Windows process — they do NOT automatically cross the WSL boundary
+ * into the bash process that wsl.exe launches. Microsoft's documented mechanism
+ * for crossing that boundary is WSLENV: a colon-delimited list of variable names
+ * (plus optional flags) that WSL copies from the Windows env into the Linux env
+ * at shell startup. See: https://learn.microsoft.com/en-us/windows/wsl/filesystems#wslenv
+ *
+ * We append to any pre-existing WSLENV on the user's Windows environment so we
+ * don't clobber their own tooling.
+ */
+export function buildWSLENV(varNames: readonly string[]): string {
+  const ours = varNames.join(':');
+  const existing = process.env.WSLENV;
+  return existing ? `${existing}:${ours}` : ours;
+}
+
+/**
  * Get shell spawn info for opening an interactive WSL terminal.
  * Returns shape compatible with ShellDetector's ShellInfo.
  */


### PR DESCRIPTION
## Summary
- Env vars passed to `pty.spawn('wsl.exe', ...)` land on the wsl.exe Windows process and never cross into bash inside the distro. That silently dropped `GIT_COMMITTER_NAME`/`_EMAIL` (Pane attribution) and every `PANE_*` var — commits made in WSL terminals didn't show "committed by Pane" on GitHub, and `$PANE_PORT` etc. were unavailable to run scripts.
- Uses `WSLENV` (Microsoft's documented mechanism): listing a var name in `WSLENV` tells WSL to copy its value from the Windows env into the Linux env at shell startup.
- Appends to any existing `WSLENV` so user tooling isn't clobbered. Gated on `wslContext && process.platform === 'win32'` — macOS, Linux, and native Windows terminals are untouched.

## Test plan
- [ ] On Windows + WSL, open a terminal panel in Pane, run `echo $GIT_COMMITTER_NAME` → should print `Pane`.
- [ ] Make a git commit inside the WSL terminal, push, and confirm GitHub shows "committed by Pane".
- [ ] Run `echo $PANE_PORT` inside WSL terminal → should print a numeric port.
- [ ] Confirm macOS and Linux terminals still work unchanged.