### PR TITLE
fix: show "Pane" in Windows notifications instead of "electron.app.Pane"

### DIFF
--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -11,6 +11,11 @@ if (process.platform === 'linux') {
 // Force integrated GPU for better battery life on dual-GPU systems
 app.commandLine.appendSwitch('force_discrete_gpu', '0');
 
+// Set Windows App User Model ID so notifications show "Pane" instead of "electron.app.Pane"
+if (process.platform === 'win32') {
+  app.setAppUserModelId('Pane');
+}
+
 // Now import the rest of electron
 import { BrowserWindow, Menu, ipcMain, shell, dialog, IpcMainInvokeEvent, session, WebContents, webContents, WebContentsView } from 'electron';
 import * as path from 'path';


### PR DESCRIPTION
## Summary
- Sets `app.setAppUserModelId('Pane')` early in the main process on Windows
- Notifications now display "Pane" instead of "electron.app.Pane"

## Test plan
- [ ] Run dev build on Windows, trigger a notification, verify it shows "Pane"