### PR TITLE
fix: use correct AUMID for Windows notification icon

### DIFF
--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -11,9 +11,10 @@ if (process.platform === 'linux') {
 // Force integrated GPU for better battery life on dual-GPU systems
 app.commandLine.appendSwitch('force_discrete_gpu', '0');
 
-// Set Windows App User Model ID so notifications show "Pane" instead of "electron.app.Pane"
+// Set Windows AUMID to match electron-builder's appId so Windows resolves
+// the installed Start Menu shortcut for notification icon and display name.
 if (process.platform === 'win32') {
-  app.setAppUserModelId('Pane');
+  app.setAppUserModelId('com.dcouple.pane');
 }
 
 // Now import the rest of electron


### PR DESCRIPTION
## Summary
- Changes `app.setAppUserModelId('Pane')` to `app.setAppUserModelId('com.dcouple.pane')` to match electron-builder's `appId`
- Windows resolves the installed Start Menu shortcut by AUMID to find the app icon and display name for toast notifications
- The previous value `'Pane'` didn't match the shortcut's registered AUMID, so Windows couldn't find the icon

## Test plan
- [ ] Install packaged build on Windows, trigger notification, verify app icon appears in toast header