### PR TITLE
fix: only notify when Pane is unfocused, collapse dual notif toggles

### DIFF
--- a/frontend/src/components/NotificationSettings.tsx
+++ b/frontend/src/components/NotificationSettings.tsx
@@ -7,8 +7,7 @@ import { Bell, BellOff, Volume2, VolumeX, Zap, Shield } from 'lucide-react';
 
 interface NotificationSettings {
   playSound: boolean;
-  notifyWhenBackgrounded: boolean;
-  notifyWhenViewingOtherPanel: boolean;
+  enabled: boolean;
 }
 
 interface NotificationSettingsProps {
@@ -145,20 +144,12 @@ export function NotificationSettings({ settings, onUpdateSettings }: Notificatio
           icon={<Zap className="w-4 h-4" />}
           spacing="sm"
         >
-          <div className="space-y-3">
-            <ToggleField
-              label="Notify when Pane is in the background"
-              description="Ping me when a panel finishes while I'm using another app"
-              checked={settings.notifyWhenBackgrounded}
-              onChange={(checked) => onUpdateSettings({ notifyWhenBackgrounded: checked })}
-            />
-            <ToggleField
-              label="Notify when viewing a different panel"
-              description="Ping me when a panel finishes while I'm looking at a different one inside Pane"
-              checked={settings.notifyWhenViewingOtherPanel}
-              onChange={(checked) => onUpdateSettings({ notifyWhenViewingOtherPanel: checked })}
-            />
-          </div>
+          <ToggleField
+            label="Desktop notifications"
+            description="Ping me when a panel finishes while Pane is in the background. Stays quiet while Pane is focused."
+            checked={settings.enabled}
+            onChange={(checked) => onUpdateSettings({ enabled: checked })}
+          />
         </SettingsSection>
       </CollapsibleCard>
     </div>

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -66,8 +66,7 @@ export function Settings({ isOpen, onClose, initialSection }: SettingsProps) {
   const [atLineCount, setAtLineCount] = useState(500);
   const [notificationSettings, setNotificationSettings] = useState({
     playSound: true,
-    notifyWhenBackgrounded: true,
-    notifyWhenViewingOtherPanel: false
+    enabled: true,
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -13,8 +13,7 @@ declare global {
 
 interface NotificationSettings {
   playSound: boolean;
-  notifyWhenBackgrounded: boolean;
-  notifyWhenViewingOtherPanel: boolean;
+  enabled: boolean;
 }
 
 // Extra delay on top of the 5s PTY idle threshold before firing a "finished"
@@ -26,8 +25,7 @@ const NOTIFICATION_DEBOUNCE_MS = 25_000;
 export function useNotifications() {
   const [settings, setSettings] = useState<NotificationSettings>({
     playSound: true,
-    notifyWhenBackgrounded: true,
-    notifyWhenViewingOtherPanel: false,
+    enabled: true,
   });
   const settingsLoaded = useRef(false);
 
@@ -37,6 +35,18 @@ export function useNotifications() {
   useEffect(() => {
     settingsRef.current = settings;
   }, [settings]);
+
+  // Window focus state synced from the main process via IPC. document.hasFocus()
+  // lies when DevTools is focused or another Electron sub-window has focus, so
+  // we use the BrowserWindow.isFocused() source of truth exposed by preload.
+  const windowFocusedRef = useRef<boolean>(typeof document !== 'undefined' ? document.hasFocus() : true);
+
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.events.onWindowFocusChanged((focused) => {
+      windowFocusedRef.current = focused;
+    });
+    return unsubscribe;
+  }, []);
 
   // Track previous activityStatus per panelId to detect active -> idle transitions.
   const prevActivityRef = useRef<Record<string, 'active' | 'idle'>>({});
@@ -138,10 +148,18 @@ export function useNotifications() {
 
   function maybeNotifyPanelIdle(panelId: string) {
     const currentSettings = settingsRef.current;
-    if (!currentSettings.notifyWhenBackgrounded && !currentSettings.notifyWhenViewingOtherPanel) return;
+    if (!currentSettings.enabled) return;
+
+    // Sole gate: window must be blurred. Everything else (same session, same
+    // panel, different panel) is moot if the user can see Pane.
+    if (windowFocusedRef.current) return;
 
     const panelStoreState = usePanelStore.getState();
-    const sessionStoreState = useSessionStore.getState();
+
+    // Re-check idle at fire time. The debounced timer may fire right as the
+    // panel re-activates; without this check we'd ping "finished" for a
+    // panel that is actively running again.
+    if (panelStoreState.activityStatus[panelId] !== 'idle') return;
 
     let foundSessionId: string | undefined;
     let foundPanel: ToolPanel | undefined;
@@ -155,31 +173,13 @@ export function useNotifications() {
     }
     if (!foundSessionId || !foundPanel) return;
 
+    const sessionStoreState = useSessionStore.getState();
     const session = sessionStoreState.sessions.find((s) => s.id === foundSessionId);
     if (!session) return;
 
-    // A panel going idle while the session is in 'waiting' state means
-    // Claude is blocked on user input, not finished. Suppress the
-    // "${panel} finished" notification entirely in that case, otherwise
-    // we would mislead the user into thinking the task completed.
+    // A panel going idle while the session is in 'waiting' state means Claude
+    // is blocked on user input, not finished. Suppress the "finished" ping.
     if (session.status === 'waiting') return;
-
-    const windowFocused = document.hasFocus();
-    const activeSessionId = sessionStoreState.activeSessionId;
-    const activePanelId = panelStoreState.activePanels[foundSessionId];
-
-    const userIsViewingThisPanel =
-      windowFocused &&
-      activeSessionId === foundSessionId &&
-      activePanelId === panelId;
-
-    if (userIsViewingThisPanel) return;
-
-    const shouldFire =
-      (currentSettings.notifyWhenBackgrounded && !windowFocused) ||
-      (currentSettings.notifyWhenViewingOtherPanel && windowFocused && !userIsViewingThisPanel);
-
-    if (!shouldFire) return;
 
     const projectName = session.projectId
       ? projectNamesRef.current.get(session.projectId) ?? ''

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -42,6 +42,17 @@ export function useNotifications() {
   const windowFocusedRef = useRef<boolean>(typeof document !== 'undefined' ? document.hasFocus() : true);
 
   useEffect(() => {
+    // Pull authoritative initial state from the main process. document.hasFocus()
+    // is a cold-start fallback; if DevTools or another Electron sub-window owns
+    // DOM focus at mount time, document.hasFocus() returns false even though
+    // BrowserWindow.isFocused() is true. Without this pull, no focus event
+    // fires until the next focus change, and notifications misfire in between.
+    window.electronAPI.window.isFocused().then((focused) => {
+      windowFocusedRef.current = focused;
+    }).catch(() => {
+      // Leave the document.hasFocus() bootstrap in place on IPC failure.
+    });
+
     const unsubscribe = window.electronAPI.events.onWindowFocusChanged((focused) => {
       windowFocusedRef.current = focused;
     });

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -27,8 +27,7 @@ export interface AppConfig {
   uiScale?: number;
   notifications?: {
     playSound: boolean;
-    notifyWhenBackgrounded: boolean;
-    notifyWhenViewingOtherPanel: boolean;
+    enabled: boolean;
   };
   devMode?: boolean;
   sessionCreationPreferences?: {

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -398,6 +398,11 @@ interface ElectronAPI {
     startActive: () => Promise<IPCResponse>;
     stopActive: () => Promise<IPCResponse>;
   };
+
+  // Window state queries (invoke, not event subscriptions)
+  window: {
+    isFocused: () => Promise<boolean>;
+  };
 }
 
 interface CloudVmState {

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -292,6 +292,9 @@ interface ElectronAPI {
     // Process management events
     onZombieProcessesDetected: (callback: (data: { sessionId?: string | null; pids?: number[]; message: string }) => void) => () => void;
 
+    // Window focus state from BrowserWindow (more reliable than document.hasFocus())
+    onWindowFocusChanged: (callback: (focused: boolean) => void) => () => void;
+
     // Spotlight events
     onSpotlightStatusChanged?: (callback: (data: { sessionId: string; projectId: number; active: boolean }) => void) => () => void;
     onSpotlightSyncError?: (callback: (data: { sessionId: string; projectId: number; error: string }) => void) => () => void;

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -819,8 +819,12 @@ async function createWindow() {
     }
   });
 
-  // Handle window focus/blur/minimize for smart git status polling
+  // Handle window focus/blur/minimize for smart git status polling and
+  // renderer-side notification gating. Send focus state to renderer so
+  // useNotifications can use the reliable BrowserWindow source of truth
+  // instead of document.hasFocus() (which lies when DevTools is focused).
   mainWindow.on('focus', () => {
+    mainWindow?.webContents.send('window:focus-changed', true);
     if (gitStatusManager) {
       gitStatusManager.handleVisibilityChange(false); // false = visible/focused
     }
@@ -828,6 +832,7 @@ async function createWindow() {
   });
 
   mainWindow.on('blur', () => {
+    mainWindow?.webContents.send('window:focus-changed', false);
     if (gitStatusManager) {
       gitStatusManager.handleVisibilityChange(true); // true = hidden/blurred
     }
@@ -835,6 +840,7 @@ async function createWindow() {
   });
 
   mainWindow.on('minimize', () => {
+    mainWindow?.webContents.send('window:focus-changed', false);
     if (gitStatusManager) {
       gitStatusManager.handleVisibilityChange(true); // true = hidden/minimized
     }
@@ -842,6 +848,8 @@ async function createWindow() {
   });
 
   mainWindow.on('restore', () => {
+    // Don't assume restore = focused. The OS will fire 'focus' if/when the user
+    // actually focuses the window. Keep git/resource hooks as-is.
     if (gitStatusManager) {
       gitStatusManager.handleVisibilityChange(false); // false = visible/restored
     }

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -847,6 +847,11 @@ async function createWindow() {
     resourceMonitorService.handleVisibilityChange(true);
   });
 
+  // Pull-path query so the renderer can get the authoritative focus state on
+  // mount without waiting for the next focus-change event. Default to true
+  // (focused) if mainWindow is somehow null at call time.
+  ipcMain.handle('window:is-focused', () => mainWindow?.isFocused() ?? true);
+
   mainWindow.on('restore', () => {
     // Don't assume restore = focused. The OS will fire 'focus' if/when the user
     // actually focuses the window. Keep git/resource hooks as-is.

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -693,6 +693,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('zombie-processes-detected', wrappedCallback);
       return () => ipcRenderer.removeListener('zombie-processes-detected', wrappedCallback);
     },
+
+    // Window focus state from BrowserWindow (more reliable than document.hasFocus())
+    onWindowFocusChanged: (callback: (focused: boolean) => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent, focused: boolean) => callback(focused);
+      ipcRenderer.on('window:focus-changed', wrappedCallback);
+      return () => ipcRenderer.removeListener('window:focus-changed', wrappedCallback);
+    },
   },
 
   // Panels API for Claude panels and other panel types

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -785,6 +785,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
     startActive: (): Promise<IPCResponse> => ipcRenderer.invoke('resource-monitor:start-active'),
     stopActive: (): Promise<IPCResponse> => ipcRenderer.invoke('resource-monitor:stop-active'),
   },
+
+  // Window state queries (invoke, not event subscriptions)
+  window: {
+    isFocused: (): Promise<boolean> => ipcRenderer.invoke('window:is-focused') as Promise<boolean>,
+  },
 });
 
 // Expose electron event listeners and utilities for permission requests

--- a/main/src/services/configManager.ts
+++ b/main/src/services/configManager.ts
@@ -35,8 +35,7 @@ export class ConfigManager extends EventEmitter {
       stravuServerUrl: '', // Stravu integration disabled
       notifications: {
         playSound: true,
-        notifyWhenBackgrounded: true,
-        notifyWhenViewingOtherPanel: false
+        enabled: true
       },
       sessionCreationPreferences: {
         sessionCount: 1,
@@ -98,14 +97,25 @@ export class ConfigManager extends EventEmitter {
       const data = await fs.readFile(this.configPath, 'utf-8');
       const loadedConfig = JSON.parse(data);
       
+      // Migrate legacy notification fields from older config files.
+      // notifyWhenBackgrounded -> enabled (if enabled is not explicitly set)
+      // notifyWhenViewingOtherPanel is dropped silently.
+      const incomingNotifications = loadedConfig.notifications as (
+        Partial<{ playSound: boolean; enabled: boolean }> &
+        { notifyWhenBackgrounded?: boolean; notifyWhenViewingOtherPanel?: boolean }
+      ) | undefined;
+      const migratedNotifications = incomingNotifications
+        ? {
+            playSound: incomingNotifications.playSound ?? this.config.notifications!.playSound,
+            enabled: incomingNotifications.enabled ?? incomingNotifications.notifyWhenBackgrounded ?? this.config.notifications!.enabled,
+          }
+        : this.config.notifications!;
+
       // Merge loaded config with defaults, ensuring nested settings exist
       this.config = {
         ...this.config,
         ...loadedConfig,
-        notifications: {
-          ...this.config.notifications,
-          ...loadedConfig.notifications
-        },
+        notifications: migratedNotifications,
         sessionCreationPreferences: {
           ...this.config.sessionCreationPreferences,
           ...loadedConfig.sessionCreationPreferences,

--- a/main/src/types/config.ts
+++ b/main/src/types/config.ts
@@ -40,8 +40,7 @@ export interface AppConfig {
   // Notification settings
   notifications?: {
     playSound: boolean;
-    notifyWhenBackgrounded: boolean;
-    notifyWhenViewingOtherPanel: boolean;
+    enabled: boolean;
   };
   // Dev mode for debugging
   devMode?: boolean;
@@ -102,8 +101,7 @@ export interface UpdateConfigRequest {
   uiScale?: number;
   notifications?: {
     playSound: boolean;
-    notifyWhenBackgrounded: boolean;
-    notifyWhenViewingOtherPanel: boolean;
+    enabled: boolean;
   };
   devMode?: boolean;
   additionalPaths?: string[];


### PR DESCRIPTION
## Summary

Notifications were firing while Pane was focused. Root cause was two bugs + a design mismatch:

1. **Flaky focus detection** — `document.hasFocus()` returns false when DevTools is focused or another Electron sub-window has focus, so the `notifyWhenBackgrounded` path fired while Pane was visibly focused.
2. **Stale timer at fire time** — the 25s debounced timer could fire just as a panel re-activated, producing "Terminal finished" for panels that were actively running again (the "fake notification" bug).
3. **Too many toggles** — `notifyWhenBackgrounded` + `notifyWhenViewingOtherPanel` created a "focused but on different panel" code path that misfired on focus-detection glitches.

## Changes

- **Single toggle**: `notifications.enabled` replaces the two legacy fields. On = notify when window is blurred. Off = never.
- **Main-process focus source of truth**: `mainWindow.on('focus'|'blur'|'minimize')` streams to renderer via new `window:focus-changed` IPC channel. `useNotifications` subscribes via `electronAPI.events.onWindowFocusChanged` (bootstrapped once from `document.hasFocus()` for first-paint).
- **Fire-time idle re-check**: `maybeNotifyPanelIdle` now short-circuits if `activityStatus[panelId] !== 'idle'` when the timer fires.
- **Config migration**: legacy `notifyWhenBackgrounded: false` maps to `enabled: false`; `notifyWhenViewingOtherPanel` dropped silently.
- **Ship default**: `enabled: true`.

## Files

- `main/src/index.ts` — broadcast focus/blur/minimize
- `main/src/preload.ts` — expose `events.onWindowFocusChanged`
- `main/src/types/config.ts`, `frontend/src/types/config.ts` — new shape
- `main/src/services/configManager.ts` — defaults + legacy migration
- `frontend/src/hooks/useNotifications.ts` — rewrite gate + re-check
- `frontend/src/components/NotificationSettings.tsx` — one toggle
- `frontend/src/components/Settings.tsx` — state shape
- `frontend/src/types/electron.d.ts` — preload type

## Test plan

- [ ] Fresh config: notifications fire only when Pane window is unfocused
- [ ] Legacy `notifyWhenBackgrounded: false` config → `enabled: false` after load
- [ ] Legacy `notifyWhenBackgrounded: true` config → `enabled: true` after load
- [ ] Start a panel, blur Pane, let it go idle 30s → one notification fires
- [ ] Start a panel, keep Pane focused, let it go idle → no notification
- [ ] Blur Pane with DevTools closed/open → behavior identical (no more `document.hasFocus` DevTools trap)
- [ ] Panel goes idle briefly then resumes before 30s → no notification
- [ ] Panel goes idle, 30s elapses, fires notification, then re-activates → no more stale-fire (new re-check kicks in at fire time)