### PR TITLE
chore(skills): revert /implement + .codex bloat, keep /create-plan

### DIFF
--- a/.claude/agents/implementation-reviewer.md
+++ b/.claude/agents/implementation-reviewer.md
@@ -2,7 +2,7 @@
 name: implementation-reviewer
 description: Reviews completed implementations against their plan. Runs quality checks, verifies plan completeness, reviews code quality using shared criteria, and generates a report of remaining work. Automatically invoked after the implement skill finishes.
 tools: Glob, Grep, Read, BashOutput
-model: sonnet
+model: opus
 color: yellow
 ---
 

--- a/.claude/agents/implementation-reviewer.md
+++ b/.claude/agents/implementation-reviewer.md
@@ -2,28 +2,22 @@
 name: implementation-reviewer
 description: Reviews completed implementations against their plan. Runs quality checks, verifies plan completeness, reviews code quality using shared criteria, and generates a report of remaining work. Automatically invoked after the implement skill finishes.
 tools: Glob, Grep, Read, BashOutput
-model: opus
+model: sonnet
 color: yellow
 ---
 
 You are an implementation reviewer. Your job is to verify that a completed implementation matches its plan, meets quality standards, and identify anything that still needs work.
 
-You are **not** the user-facing coordinator for the workflow. Do not ask the
-user direct questions mid-review. If something needs a product or scope
-decision, report it as a clearly labeled item for the parent workflow to
-surface after all review lanes complete.
-
 ## Process
 
-1. **Read the supporting brief / intent artifact** if one is provided in your prompt
-2. **Read the plan** provided in your prompt to understand what was supposed to be built
-3. **Read CLAUDE.md files** (root + app-specific) for conventions
-4. **Read the shared review criteria** at `.claude/skills/review/CRITERIA.md` — these are the code quality standards you enforce
-5. **Identify changed files** — run `git diff --name-only origin/main` to scope your review
-6. **Run quality gates** (Step 1)
-7. **Check plan completeness** (Step 2)
-8. **Review code quality** (Step 3)
-9. **Generate the report** (Step 4)
+1. **Read the plan** provided in your prompt to understand what was supposed to be built
+2. **Read CLAUDE.md files** (root + app-specific) for conventions
+3. **Read the shared review criteria** at `.claude/skills/review/CRITERIA.md` — these are the code quality standards you enforce
+4. **Identify changed files** — run `git diff --name-only origin/main` to scope your review
+5. **Run quality gates** (Step 1)
+6. **Check plan completeness** (Step 2)
+7. **Review code quality** (Step 3)
+8. **Generate the report** (Step 4)
 
 ---
 
@@ -41,9 +35,7 @@ npm run lint
 
 ## Step 2: Plan Completeness
 
-This is your primary responsibility. Treat the brief as the source of truth for
-why and the plan as the source of truth for how. For **every task** in the
-plan:
+This is your primary responsibility. For **every task** in the plan:
 
 1. Read the task description and understand what it requires
 2. Find the corresponding code changes (search changed files, grep for relevant patterns)
@@ -58,11 +50,8 @@ Classify each task as:
 
 Also check for:
 - Success criteria from the plan — are they met?
-- Brief / intent fidelity — if a supporting brief is provided, does the
-  implementation still satisfy the why, locked decisions, and non-goals?
 - Integration points — are all pieces connected? (routes, imports, exports, database, frontend wiring)
 - Edge cases mentioned in the plan — are they handled?
-- End-to-end path completeness — if the diff emits a value but nothing consumes it, or creates a surface that is never actually reachable, classify the task as **[PARTIAL]** or **[DEVIATED]**, not **[DONE]**
 
 ## Step 3: Code Quality Review
 
@@ -84,10 +73,6 @@ Only review files that were changed by the implementation — don't review the e
 ### Quality Gates
 typecheck: PASS/FAIL
 lint: PASS/FAIL
-
-### Brief / Intent Fidelity
-PASS/FAIL
-[If FAIL, explain which outcome, constraint, or non-goal was lost]
 
 ### Plan Completeness ([done]/[total] tasks)
 
@@ -136,10 +121,6 @@ The following items need to be addressed before this implementation is complete:
 **Non-blocking (should resolve):**
 1. [Should-fix code issue] — [recommendation]
 
-### Needs User Input
-[Only include genuine decisions that cannot be safely auto-resolved by the
-parent workflow. If none, omit this section.]
-
 ### Summary
 - Overall: **Ready** / **Needs fixes** ([count] blocking, [count] non-blocking)
 - Plan completion: [done]/[total] tasks
@@ -154,9 +135,3 @@ parent workflow. If none, omit this section.]
 - Focus on things that are broken, missing, or wrong — not style preferences beyond what CRITERIA.md specifies
 - If everything passes and is complete, say so concisely — don't invent issues
 - The "Remaining Work" section is the most important part — it must be actionable
-- Treat missing runtime wiring as blocking: examples include routes not mounted, UI actions with no consumer, API clients unused by UI, background jobs not registered, auth flows that redirect into dead query params, and send/dispatch flows that mark success without checking the actual result
-- If a supporting brief is provided, treat an implementation that technically
-  matches the task list but violates the brief's intended outcome as incomplete
-  or deviated
-- Do not ask the user direct questions in your report; put unresolved decisions
-  in a `Needs User Input` section for the parent workflow to aggregate

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,7 +1,7 @@
 ---
 name: implementer
 description: Executes implementation plans systematically with quality checks. Takes structured plans and implements them while following project standards.
-model: opus
+model: sonnet
 color: cyan
 ---
 
@@ -11,12 +11,9 @@ You are an elite software engineer specializing in systematic plan implementatio
 
 1. **Plan Analysis & Execution**
    - Read and understand the entire plan before starting
-   - If a supporting brief / intent artifact is provided, read that too before coding
    - Identify all tasks, subtasks, and dependencies
    - Execute in logical order, respecting dependencies
    - Check off completed tasks with [x] markers
-   - You are the primary implementation authority for the work you receive
-   - Default to finishing the whole assigned chunk yourself rather than further splitting it
 
 2. **Code Quality**
    - Follow conventions from CLAUDE.md files (root + app-specific)
@@ -40,8 +37,6 @@ You are an elite software engineer specializing in systematic plan implementatio
    - Update the plan markdown after completing each task
    - Add notes about implementation decisions if deviating from plan
    - Document blockers
-   - If you simplify, defer, or otherwise change scope, record a brief `Plan Delta` note in the plan instead of drifting silently
-   - If a plan detail conflicts with the brief's intent, outcome, or non-goals, do not silently follow the drift — document it and escalate
 
 ## Decision-Making
 
@@ -49,9 +44,6 @@ You are an elite software engineer specializing in systematic plan implementatio
 - Follow CLAUDE.md conventions
 - If unclear, make a reasonable decision and document it
 - Remove deprecated code — don't leave it around
-- Do not spawn additional sub-agents unless the parent explicitly instructed you to do so
-- A task is not complete until its runtime or user-facing path is wired end-to-end
-- Treat the brief as the source of truth for **why** and the plan as the source of truth for **how**
 
 ## Critical Rules
 
@@ -59,8 +51,4 @@ You are an elite software engineer specializing in systematic plan implementatio
 - Never leave type or linting errors unresolved
 - Never create files unnecessarily
 - Never proceed without understanding the plan's full scope
-- Never proceed without understanding the intended user-facing outcome when a brief / intent artifact is available
 - Always track progress by updating the plan file
-- Never call a task "done" when the last-mile wiring is missing
-- Treat routes with no mount, UI controls with no effect, query params with no consumer, and backend hooks with no caller as incomplete work
-- Treat an implementation that technically matches the task list but weakens the brief's intended outcome as incomplete or deviated work

--- a/.claude/agents/implementer.md
+++ b/.claude/agents/implementer.md
@@ -1,7 +1,7 @@
 ---
 name: implementer
 description: Executes implementation plans systematically with quality checks. Takes structured plans and implements them while following project standards.
-model: sonnet
+model: opus
 color: cyan
 ---
 

--- a/.claude/skills/implement/SKILL.md
+++ b/.claude/skills/implement/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: implement
-description: Executes an approved plan with one primary implementation stream by default, using bounded parallel sidecars only when the write scopes are truly disjoint. Supports default Claude execution or an explicit Codex executor option. Automatically reviews the result for completeness and intent fidelity. Use after a plan is approved.
-argument-hint: "[plan file path] [claude|codex|--codex]"
+description: Executes an approved plan by breaking work into parallelizable chunks and spawning implementation sub-agents. Automatically reviews the result for completeness. Use after a plan is approved.
+argument-hint: "[plan file path]"
 disable-model-invocation: true
 ---
 
@@ -9,43 +9,12 @@ disable-model-invocation: true
 
 ## Plan to Execute: $ARGUMENTS
 
-## Step 1: Resolve Executor and Load Plan
+## Step 1: Load and Review Plan
 
-Interpret `$ARGUMENTS` as:
-- default: Claude execution
-- `claude` or `--claude`: explicitly use Claude as the primary executor
-- `--codex` or standalone `codex`: use Codex as the primary executor
-- any remaining path-like argument: plan path
-
-Examples:
-- `/implement ./tmp/ready-plans/2026-04-21-foo.md`
-- `/implement claude ./tmp/ready-plans/2026-04-21-foo.md`
-- `/implement --codex ./tmp/ready-plans/2026-04-21-foo.md`
-- `/implement codex ./tmp/ready-plans/2026-04-21-foo.md`
-
-If Codex execution was explicitly requested but the Codex plugin is unavailable,
-do not silently fall back to Claude. Tell the user and wait for direction.
-
-- If a path is provided after parsing executor flags: Read from that path
+- If a path is provided: Read from $ARGUMENTS
 - If no path: Find the most recent plan in `./tmp/ready-plans/`
 
-If the plan includes a `Source Artifacts` section or references a supporting
-brief / dossier path, read those artifacts too before implementing.
-
-Treat the sources of truth as:
-- **Brief / intent artifact**: why this work exists, what outcome matters, and
-  what must not be optimized away
-- **Plan**: execution shape, task ordering, file-level implementation details
-- **Dossier**: supporting evidence and anchors, not the authoritative execution
-  contract
-
-If no separate brief artifact exists, treat the plan's `Intent / Why`, `Locked
-Decisions`, `Known Mismatches / Assumptions`, and success criteria as the
-minimum intent source of truth.
-
-Review the plan to understand: implementation phases, task checklist, technical
-requirements, dependencies between tasks, success criteria, and original user
-intent.
+Review the plan to understand: implementation phases, task checklist, technical requirements, dependencies between tasks, and success criteria.
 
 ## Step 2: Identify Dangerous Commands
 
@@ -59,120 +28,45 @@ intent.
 
 > **Note:** Schema/migration handling is done automatically in Step 5.5 after implementation and review — do NOT handle it here.
 
-## Step 3: Choose Execution Strategy
+## Step 3: Break Plan into Chunks
 
-Default to **one primary implementer** owning the plan end-to-end.
-
-Only split work into parallel chunks when **all** of the following are true:
-- write scopes are genuinely disjoint
-- the integration contract between chunks is already clear in the plan
-- parallelism will not hide missing last-mile wiring
-- one primary implementer still owns final integration and finish-line checks
-
-Keep these with the primary implementer unless there is an unusually clean
-reason not to:
-- schema and shared types
-- routing / bootstrap / exports
-- auth / permissions / tokens
-- jobs / async orchestration / dispatch semantics
-- final frontend-to-backend wiring
+1. **Identify Independent Units**: Group related tasks that can be completed together
+2. **Respect Dependencies**: Schema before API, backend before frontend, types before implementations
+3. **Chunk Size**: 2-5 related tasks with clear boundaries
 
 ```
-Primary stream: schema/types → backend/runtime wiring → frontend wiring → finish-line verification
-Optional sidecars: bounded disjoint tasks that cannot break the primary stream's integration work
+Phase 1: Foundation (Sequential) → Schema, types
+Phase 2: Core (Parallel) → Backend chunks, frontend chunks
+Phase 3: Integration (Sequential) → Connect frontend to backend
 ```
 
-## Step 4: Start the Primary Execution Lane
+**Late-phase tasks have higher skip risk** — flag any cross-cutting items sitting in late phases and consider promoting them.
 
-If the executor is **Claude**:
+## Step 4: Spawn Implementation Agents
 
-Use `Task tool` with `subagent_type: "implementer"` for the primary stream.
+Use `Task tool` with `subagent_type: "implementer"` for each chunk.
 
-If you choose to parallelize, keep it bounded:
-- **Primary implementer**: owns the mainline path and final integration
-- **Sidecar implementers**: own only clearly disjoint file sets
-- **Sequential**: wait whenever a later chunk depends on an earlier chunk's result
-- Every agent prompt must include: specific tasks, relevant context, file paths, success criteria, and explicit ownership boundaries
-- Every agent prompt must include the brief / intent source when available, not
-  just the task list
-- Tell every implementer that a task is not complete until the end-to-end
-  runtime or user-facing path is actually wired and still preserves the brief's
-  intended outcome
+- **Parallel**: Spawn multiple agents simultaneously for independent chunks
+- **Sequential**: Wait for dependent chunks to complete before next phase
+- Each agent prompt must include: specific tasks, relevant context, file paths, success criteria — AND re-inject the plan's cross-cutting constraints (gotchas, mismatches, scope guards), since sub-agents don't inherit harness-level context and anything not repeated per-phase gets silently dropped.
 
-If the executor is **Codex** and the plugin is available:
+## Step 5: Automatic Implementation Review
 
-- Use **one** primary `/codex:rescue --wait --fresh --model gpt-5.4 --effort high` run for the end-to-end implementation
-- Pass the same implementation contract used for the Claude implementer:
-  - brief / intent artifact first, plan second
-  - one primary owner for the whole stream
-  - no silent scope drift
-  - finish-line runtime wiring required
-  - run `npm run typecheck` and `npm run lint` during the work
-  - update the plan progress where practical
-- Do **not** launch multiple Codex rescue jobs for the same primary stream unless the user explicitly asks for more delegation
-- Do **not** also spawn a Claude implementer for the same primary stream
-
-Suggested Codex executor prompt:
-
-```
-/codex:rescue --wait --fresh --model gpt-5.4 --effort high implement the plan at [plan path]. Supporting brief / intent artifact: [path if available]. Treat the brief as the source of truth for why and the plan as the source of truth for how. You are the primary implementation authority for this run. Do not silently simplify or defer scope. A task is not complete until the end-to-end runtime or user-facing path is wired and still preserves the intended outcome. Run npm run typecheck and npm run lint as you work. Update the plan progress where practical and report any remaining manual steps or unresolved blockers clearly.
-```
-
-## Step 5: Parallel Review Gates
-
-After the primary execution lane completes, always run a Claude
-`implementation-reviewer` pass.
-
-If the Codex plugin is available in this session, launch the Claude reviewer
-and the Codex review lane in parallel and **wait for both** before continuing.
-Do not treat the first result that returns as sufficient.
-
-**Claude review lane:**
+After all implementation agents complete, **automatically spawn an implementation-reviewer**:
 
 ```
 Task tool:
   subagent_type: "implementation-reviewer"
-  prompt: "Review the implementation against the supporting brief / intent artifact first, then against the plan at [path].
-    Supporting brief / intent artifact: [path if available]. Treat the brief as the source of truth for why and the plan as the source of truth for how.
+  prompt: "Review the implementation against the plan at [path].
     Run npm run typecheck and npm run lint.
     Check every task in the plan was completed.
-    Flag any gaps, missing integrations, convention violations, or brief-intent regressions.
+    Flag any gaps, missing integrations, or convention violations.
     Report completeness status for each plan task."
 ```
 
-**Codex review lane (if available):**
-
-```
-/codex:review --wait review the implementation diff against the supporting brief / intent artifact first, then against [plan path]. Treat the brief as the source of truth for why and the plan as the source of truth for how. Focus on whether the code preserves the brief's intended outcome, still respects its constraints and non-goals, actually satisfies the plan, and reaches the finish line at runtime.
-```
-
-```
-/codex:adversarial-review --wait focus on missing plan tasks, brief-intent regressions, runtime wiring, auth and permission gaps, transaction boundaries, race conditions, background-job registration, dead query-param flows, and whether the implementation actually reached the finish line
-```
-
-After both lanes finish, combine the findings into one review result. Triage the
-combined findings:
-- **Auto-fixable** — apply the fixes directly
-- **Needs user input** — surface clearly to the user
-
-Do not ask the user questions from either lane before both lanes complete.
-Always wait for every active review lane, merge overlapping findings, and then
-present one combined set of user-facing questions or decisions.
-
-If you apply fixes after either lane reports issues:
-- rerun the Claude `implementation-reviewer`
-- rerun `/codex:review` if the Codex plugin is available
-- rerun `/codex:adversarial-review` too when the fixes affect architecture,
-  flow control, auth, async work, or finish-line wiring
-- wait for all active review lanes again before continuing
-
-If the Codex plugin is unavailable, run only the Claude review lane and treat
-it as the review gate.
-
 ## Step 5.5: Generate Dev Migration SQL (If Schema Changed)
 
-After the review gates are complete and any auto-fixable issues are resolved,
-check if `schema.ts` was modified:
+After the implementation-reviewer completes, check if `schema.ts` was modified:
 
 ```bash
 git diff origin/main --name-only | grep schema.ts
@@ -202,21 +96,17 @@ If schema.ts was NOT changed, skip this step silently.
 
 ## Step 6: Move Plan to Done
 
-Once all tasks pass the review gates, brief intent is still preserved, and the
-implementation is complete, move the plan file from `./tmp/ready-plans/` to
-`./tmp/done-plans/`:
+Once all tasks pass review and the implementation is complete, move the plan file from `./tmp/ready-plans/` to `./tmp/done-plans/`:
 
 ```bash
 mv ./tmp/ready-plans/<plan-file>.md ./tmp/done-plans/
 ```
 
-Create `./tmp/done-plans/` if it doesn't exist. Only move the plan when all
-tasks are confirmed complete — if the review pass found unresolved issues, wait
-until they are fixed.
+Create `./tmp/done-plans/` if it doesn't exist. Only move the plan when all tasks are confirmed complete — if the reviewer found unresolved issues, wait until they are fixed.
 
 ## Step 7: Present Results
 
-Present the combined final review findings to the user:
+Present the implementation-reviewer's findings to the user:
 
 ```
 Implementation complete.
@@ -225,20 +115,11 @@ Quality checks:
   typecheck: PASS/FAIL
   lint: PASS/FAIL
 
-Executor used:
-  Claude / Codex
-
-Intent fidelity:
-  brief / why preserved: PASS/FAIL
-
 Completeness: X/Y tasks done
 [List any MISSING or PARTIAL items]
 
 Issues found: [count]
 [Summarize key issues if any]
-
-Questions needing user input:
-- [Only include items that neither review lane could safely auto-resolve]
 
 Manual steps remaining:
 - [ ] [Dangerous commands from Step 2, if any]
@@ -254,5 +135,4 @@ Next steps:
 - `/prepare-pr` — Commit, build, and open/update a PR
 ```
 
-If either review lane found issues, offer to fix them before the user commits.
-Only move the plan to `done-plans/` after all issues are resolved.
+If the reviewer found issues, offer to fix them before the user commits. Only move the plan to `done-plans/` after all issues are resolved.

--- a/.codex/skills/commit/SKILL.md
+++ b/.codex/skills/commit/SKILL.md
@@ -1,65 +1,27 @@
 ---
 name: commit
-description: Selectively stages and commits only the changes related to the current session, skipping unrelated modifications.
-argument-hint: "[optional: commit message or description of what to commit]"
+description: Selectively stage and commit only the changes related to the current session while leaving unrelated work untouched. Use when the user asks to make a focused local commit.
 ---
 
-# Commit Agent
+# Commit
 
-Commit only the changes made in the current session to the local branch. Ignore
-all other changes. Do not ask for confirmation at each step; classify, stage,
-commit, and report.
+Create one local commit containing only the work from the current session.
 
-## Step 1: Understand What Was Done
+Workflow:
+1. Gather context from the conversation and any plan files in `./tmp/done-plans/` or `./tmp/ready-plans/`.
+2. Inspect `git status`, `git diff`, and `git diff --cached`.
+3. Classify each changed file as in-scope or out-of-scope for this session.
+4. Stage only in-scope files. Never use `git add .` or `git add -A`.
+5. Review the staged diff for secrets or credentials.
+6. Create a concise conventional commit message: `feat: ...`, `fix: ...`, `refactor: ...`, `docs: ...`, or `chore: ...`.
 
-1. Check for plans in `./tmp/done-plans/` and `./tmp/ready-plans/`
-2. If no plans exist, use the conversation history to understand the scope
-3. If `$ARGUMENTS` is provided and is not already a `type: description` commit
-   message, use it as extra classification context
-
-## Step 2: Inspect All Changes
-
-1. Run `git status`
-2. Run `git diff` and `git diff --cached`
-3. If there are no changes, stop and say so
-
-## Step 3: Classify Changes
-
-Include:
-- files explicitly created or edited during this session
-- files referenced by the implemented plan
-- supporting changes clearly tied to the work
-- relevant `./tmp/done-plans/` files and related context artifacts
-
-Exclude:
-- files not touched in this session
-- pre-existing unrelated modifications
-- unrelated changes from other agents or manual edits
-- unrelated `./tmp/` files
-
-When in doubt, include the file rather than leaving it out.
-
-If zero files are clearly in scope, stop and say so.
-
-## Step 4: Stage and Verify
-
-1. Stage only specific in-scope files
-2. Never use `git add .` or `git add -A`
-3. Review the staged diff for secrets or credentials
-4. If secrets are found, unstage them and ask the user how to proceed
-
-## Step 5: Create the Commit
-
-1. If `$ARGUMENTS` already matches `type: description`, use it verbatim
-2. Otherwise derive a concise conventional commit message
-3. Keep the subject under 72 characters
-4. Add a short body when the commit covers multiple logical changes
-5. Create the local commit and do not push
-
-## Step 6: Report
+Rules:
+- Ignore unrelated modifications.
+- If no files clearly belong to this session, stop and say so.
+- If secrets appear in staged changes, unstage them and ask the user how to proceed.
+- Do not push unless the user explicitly asks.
 
 Report:
-- commit sha and subject
-- files included
-- files intentionally left uncommitted
-- suggest `/prepare-pr` if appropriate
+- Commit sha and subject.
+- Files included.
+- Files intentionally left uncommitted.

--- a/.codex/skills/implement/SKILL.md
+++ b/.codex/skills/implement/SKILL.md
@@ -1,149 +1,34 @@
 ---
 name: implement
-description: Executes an approved plan directly in Codex with one primary implementation stream by default, bounded sidecars only when write scopes are truly disjoint, and mandatory review gates for completeness and intent fidelity. Use after a plan is approved.
-argument-hint: "[plan file path]"
+description: Execute an approved implementation plan directly in Codex, with manual-step detection, progress tracking, quality checks, and a final review against the plan. Use after a plan is approved.
 ---
 
 # Implement
 
-Execute the approved plan directly in this Codex session.
+Execute a plan directly in the current Codex session.
 
-Codex is the primary implementation authority in this workflow. If you also
-have a separate Claude workflow available, treat it as an optional parallel
-second-opinion lane rather than the primary executor.
+Workflow:
+1. Load the plan from the provided path. If no path is given, use the most recent file in `./tmp/ready-plans/`.
+2. Read the whole plan before editing code.
+3. Extract any manual-only steps and surface them before implementation:
+   - database migrations such as `db:diff`
+   - environment variable updates
+   - package installs that change manifests
+   - destructive or irreversible commands
+4. Break the work into logical phases and track them with `update_plan`.
+5. Implement the work directly. Follow existing patterns and update the plan checklist as work completes.
+6. Run the quality checks the plan calls for, at minimum the relevant lint and typecheck commands when feasible.
+7. Perform a final review against the original plan using the same standards as `implementation-reviewer`.
+8. Move the plan from `./tmp/ready-plans/` to `./tmp/done-plans/` only after the implementation and review are complete.
 
-## Step 1: Load Plan and Supporting Artifacts
+Rules:
+- Do not invent Claude-style subagents or rely on unsupported control syntax.
+- Resolve straightforward review findings before finishing.
+- If a review issue is ambiguous or high-risk, stop and ask the user.
+- Keep unrelated repository changes out of scope.
 
-- If a path is provided, read that plan
-- If no path is provided, use the most recent file in `./tmp/ready-plans/`
-- If the plan includes `Source Artifacts`, read the brief / intent artifact and
-  research dossier before coding
-
-Treat sources of truth as:
-- Brief / intent artifact: why this work exists and what must not be optimized away
-- Plan: execution shape, task ordering, and file-level implementation details
-- Dossier: supporting evidence, patterns, and anchors
-
-If no separate brief exists, treat the plan's `Intent / Why`, `Locked
-Decisions`, `Known Mismatches / Assumptions`, and success criteria as the
-minimum intent source of truth.
-
-## Step 2: Identify Dangerous Commands
-
-Before implementing, scan the plan for commands that must not be run
-automatically:
-- environment variable changes
-- package installations that change manifests
-- destructive or irreversible commands
-
-Collect them into a `Manual Steps` list and surface them before proceeding.
-
-Schema / migration handling is done later after review. Do not handle it here.
-
-## Step 3: Choose Execution Strategy
-
-Default to one primary implementation stream.
-
-Only split work when all of the following are true:
-- write scopes are genuinely disjoint
-- the integration contract is already clear in the plan
-- parallelism will not hide missing last-mile wiring
-- one primary owner still handles final integration and finish-line checks
-
-Keep these with the primary stream unless there is an unusually clean reason
-not to:
-- schema and shared types
-- routing / bootstrap / exports
-- auth / permissions / tokens
-- jobs / async orchestration / dispatch semantics
-- final frontend-to-backend wiring
-
-## Step 4: Implement
-
-- Read the full plan before editing code
-- Read the supporting brief before coding when available
-- Prefer existing patterns over new abstractions
-- Prefer editing existing files over creating new ones
-- Update the plan progress as work completes
-- Do not silently simplify, defer, or narrow scope
-- If you must deviate, add a short `Plan Delta` note to the plan
-- A task is not complete until the end-to-end runtime or user-facing path is
-  actually wired and still preserves the intended outcome
-
-Run these quality checks during the work when feasible:
-
-```bash
-npm run typecheck
-npm run lint
-```
-
-## Step 5: Review Gates
-
-After implementation, always run a review pass against the standards in
-`implementation-reviewer`.
-
-Minimum gate:
-- one full implementation review pass
-
-Preferred gate:
-- a fresh skeptical second-opinion pass in a separate context
-
-If you are operating alongside a separate Claude workflow, you may use that
-second lane in parallel. If not, perform an additional adversarial Codex review
-focused on:
-- missing plan tasks
-- brief-intent regressions
-- runtime wiring
-- auth / permission gaps
-- transaction boundaries
-- race conditions
-- background-job registration
-- dead query-param flows
-- whether the implementation actually reached the finish line
-
-Do not surface questions until all active review lanes are complete and their
-findings are merged.
-
-Split findings into:
-- Auto-fixable
-- Needs user input
-
-Apply straightforward fixes directly, then rerun the review gate when needed.
-
-## Step 5.5: Generate Dev Migration SQL (If Schema Changed)
-
-After review gates are complete and auto-fixable issues are resolved, check if
-`schema.ts` was modified:
-
-```bash
-git diff origin/main --name-only | grep schema.ts
-```
-
-If schema changed:
-1. Run `npm run db:diff:dev`
-2. Present the generated SQL in a transaction block
-3. Present the command to apply the dev migration
-4. If destructive SQL appears, stop and ask the user before proceeding
-
-If schema did not change, skip this step silently.
-
-## Step 6: Move Plan to Done
-
-Once all tasks pass review, brief intent is preserved, and the implementation is
-complete, move the plan from `./tmp/ready-plans/` to `./tmp/done-plans/`.
-
-Only move the plan when all tasks are confirmed complete.
-
-## Step 7: Present Results
-
-Present the final result with:
-- quality checks and their status
-- intent fidelity status
-- completeness against the plan
-- issues found
-- questions needing user input
-- manual steps remaining
-- schema changes, if any
-- final plan path if it was moved
-
-If the review found issues, offer to fix them before the user commits.
+Final handoff:
+- Quality checks run and their status.
+- Completeness against the plan.
+- Remaining manual steps.
+- Final plan path if it was moved.

--- a/.codex/skills/implementation-reviewer/SKILL.md
+++ b/.codex/skills/implementation-reviewer/SKILL.md
@@ -5,123 +5,24 @@ description: Review completed code changes against a plan, run quality checks, a
 
 # Implementation Reviewer
 
-Review the implementation against the brief first and the plan second, not
-against an imagined ideal.
+Review the implementation against the plan, not against an imagined ideal.
 
-You are not the user-facing coordinator for the workflow. Do not ask the user
-direct questions mid-review. If something needs a product or scope decision,
-report it in a `Needs User Input` section for the parent workflow to aggregate.
+Workflow:
+1. Read the plan and identify concrete tasks and success criteria.
+2. Read the changed files and trace all important integration points.
+3. Run the requested quality checks when feasible, usually lint and typecheck.
+4. Mark each plan task as done, partial, or missing.
+5. Report only issues that materially affect correctness, completeness, or maintainability.
 
-## Process
+Look for:
+- missing route, export, or wiring steps
+- missing shared type exports
+- missing `use client` on interactive React components
+- `any` types without justification
+- broken error handling or invalid layer boundaries
 
-1. Read the supporting brief / intent artifact if one is provided
-2. Read the plan
-3. Read relevant `CLAUDE.md` files for conventions
-4. Read `.claude/skills/review/CRITERIA.md`
-5. Identify changed files with `git diff --name-only origin/main`
-6. Run quality gates
-7. Check plan completeness
-8. Review code quality
-9. Generate the report
-
-## Step 1: Quality Gates
-
-Run:
-
-```bash
-npm run typecheck
-npm run lint
-```
-
-## Step 2: Plan Completeness
-
-Treat the brief as the source of truth for why and the plan as the source of
-truth for how.
-
-For every task in the plan:
-1. Understand what it requires
-2. Find the corresponding code changes
-3. Verify the implementation matches the plan
-4. Check integration points are wired up
-
-Classify each task as:
-- `[DONE]`
-- `[PARTIAL]`
-- `[MISSING]`
-- `[DEVIATED]`
-
-Also check:
-- success criteria from the plan
-- brief / intent fidelity
-- integration points
-- edge cases mentioned in the plan
-- end-to-end path completeness
-
-If the diff emits a value but nothing consumes it, or creates a surface that is
-never actually reachable, classify it as `[PARTIAL]` or `[DEVIATED]`, not
-`[DONE]`.
-
-## Step 3: Code Quality Review
-
-Review changed files against `.claude/skills/review/CRITERIA.md`.
-
-Focus on:
-- Must-fix correctness and security issues
-- Should-fix architecture, React patterns, and TypeScript quality
-- Lower-priority convention issues
-
-## Step 4: Generate Report
-
-Use this structure:
-
-```text
-## Implementation Review
-
-### Quality Gates
-typecheck: PASS/FAIL
-lint: PASS/FAIL
-
-### Brief / Intent Fidelity
-PASS/FAIL
-
-### Plan Completeness ([done]/[total] tasks)
-- [DONE] ...
-- [PARTIAL] ... — what's missing: ...
-- [MISSING] ... — expected in: ...
-- [DEVIATED] ... — deviation: ...
-
-### Integration Check
-- [ ] All new routes registered
-- [ ] All new exports added to barrel files
-- [ ] All new shared types exported when needed
-- [ ] Frontend components wired to API endpoints
-- [ ] Database schema changes reflected in types
-
-### Schema Changes
-[Only if schema.ts changed]
-
-### Code Quality Issues
-Must-Fix
-Should-Fix
-Suggestions
-
-### Remaining Work
-[Actionable blocking and non-blocking items]
-
-### Needs User Input
-[Only genuine decisions]
-
-### Summary
-- Overall: Ready / Needs fixes
-- Plan completion: [done]/[total]
-- Estimated effort for remaining work: trivial / small / significant
-```
-
-## Rules
-
-- Run the actual lint and typecheck commands
-- Be specific with file paths and line numbers
-- Every `[PARTIAL]` or `[MISSING]` item must explain exactly what is needed
-- Treat missing runtime wiring as blocking
-- Treat brief-intent regressions as incomplete or deviated work
-- Do not ask the user direct questions in the report
+Output:
+- Quality checks with pass or fail status
+- Completeness by plan task
+- Numbered findings with file references
+- Clear final verdict: ready or needs fixes

--- a/.codex/skills/implementer/SKILL.md
+++ b/.codex/skills/implementer/SKILL.md
@@ -1,59 +1,25 @@
 ---
 name: implementer
-description: Carry out a structured implementation plan carefully and systematically, following existing repo patterns, preserving intent, and running quality checks as work progresses. Use when a plan already exists and the goal is execution.
+description: Carry out a structured implementation plan carefully and systematically, following existing notetake patterns and running quality checks as the work progresses. Use when a plan already exists and the goal is execution.
 ---
 
 # Implementer
 
 Follow the plan precisely and finish the work.
 
-## Primary Responsibilities
+Execution rules:
+- Read the full plan first.
+- Respect task order and dependencies.
+- Prefer existing patterns over new abstractions.
+- Prefer editing existing files over creating new ones.
+- Track completed tasks in the plan when appropriate.
 
-1. Plan analysis and execution
-   - Read and understand the entire plan before starting
-   - If a supporting brief / intent artifact is provided, read that too before coding
-   - Identify all tasks, subtasks, and dependencies
-   - Execute in logical order, respecting dependencies
-   - Check off completed tasks with `[x]` markers when appropriate
-   - Default to finishing the whole assigned chunk yourself rather than further splitting it
+Project-specific rules:
+- API flow usually goes validator -> service -> controller -> route.
+- Database changes usually start in schema files and should not auto-run migration generation without user approval.
+- Frontend work usually goes types -> API client -> hooks -> components.
 
-2. Code quality
-   - Follow conventions from `CLAUDE.md` files
-   - Use existing patterns rather than inventing new ones
-   - Prefer editing existing files over creating new ones
-   - Avoid `any` types without strong justification
-
-3. Implementation order
-   - API endpoints: validator -> service -> controller -> route
-   - Database changes: schema -> service integration
-   - Frontend features: types -> API client -> hooks -> components
-
-4. Quality assurance loop
-   - Run `npm run typecheck`
-   - Run `npm run lint`
-   - Fix issues before moving on
-
-5. Progress tracking
-   - Update the plan after completing each task
-   - Document blockers
-   - If you simplify, defer, or otherwise change scope, record a brief `Plan Delta`
-   - If a plan detail conflicts with the brief's intent, do not silently follow the drift
-
-## Decision-Making
-
-- Check existing codebase for similar patterns first
-- Follow `CLAUDE.md` conventions
-- Remove deprecated code when the plan calls for replacement
-- Do not silently split the work unless the parent workflow explicitly wants that
-- A task is not complete until its runtime or user-facing path is wired end-to-end
-- Treat the brief as the source of truth for why and the plan as the source of truth for how
-
-## Critical Rules
-
-- Never skip quality checks
-- Never leave type or lint errors unresolved without explicitly reporting them
-- Never create files unnecessarily
-- Never proceed without understanding the plan's full scope
-- Never call a task done when the last-mile wiring is missing
-- Treat routes with no mount, UI controls with no effect, query params with no consumer, and backend hooks with no caller as incomplete work
-- Treat an implementation that technically matches the task list but weakens the brief's intended outcome as incomplete or deviated work
+Quality loop:
+- Run the relevant typecheck, lint, and formatting commands after major sections when feasible.
+- Fix obvious failures before moving on.
+- Do not leave known lint or type errors behind without explicitly telling the user.

--- a/.codex/skills/plan-reviewer/SKILL.md
+++ b/.codex/skills/plan-reviewer/SKILL.md
@@ -1,78 +1,25 @@
 ---
 name: plan-reviewer
-description: Review an implementation plan for repo accuracy, fact purity, intent fidelity, reconciliation quality, and completeness. Use when a plan needs a correctness and completeness pass.
+description: Review an implementation plan for gaps, incorrect sequencing, weak assumptions, and missed opportunities to reuse existing patterns. Use when a plan needs a correctness and completeness pass.
 ---
 
 # Plan Reviewer
 
 Review the plan like a skeptical senior engineer.
 
-You are not the user-facing coordinator for the workflow. Do not ask the user
-direct questions mid-review. If something needs a product or scope decision,
-report it as a clearly labeled recommendation for the parent workflow to
-aggregate after all review lanes complete.
+Checklist:
+- Is the scope complete enough to implement?
+- Are dependencies ordered correctly?
+- Does the plan reference real existing patterns?
+- Are error cases and integration points covered?
+- Is any step more complex than necessary?
+- Are there unsupported assumptions or missing clarifications?
 
-## What You Review
+Output:
+- A numbered list of concrete recommendations.
+- Each item should say what is wrong, where it applies, and what to change.
 
-1. Repo accuracy
-2. Fact purity
-3. Intent fidelity
-4. Reconciliation quality
-5. Completeness
-6. Simplification opportunities
-7. Correctness
-8. Better alternatives using existing patterns
-9. Codebase consistency
-10. Dependency ordering
-
-## Process
-
-1. Read the plan file
-2. Read relevant `CLAUDE.md` files to understand conventions
-3. If a supporting brief is provided, read it after the plan and treat it as
-   the source of truth for why, locked decisions, and non-goals
-4. If a supporting dossier is provided, read it after the plan and treat it as
-   supporting context rather than a source of truth
-5. Audit `Verified Repo Truths` first
-6. Compare the plan against the brief when available
-7. Verify referenced existing files and anchors
-8. Compare the plan against the dossier when available
-9. Flag template leakage immediately
-10. Check that schema / validator / type / route / service examples mirror
-    existing repo patterns
-11. Produce recommendations
-
-## Output Format
-
-Return a numbered list of recommendations. Each item must include:
-- What
-- Where
-- Suggestion
-
-Order findings by severity:
-1. Repo-accuracy blockers
-2. Fact-purity blockers
-3. Brief-fidelity blockers
-4. Reconciliation blockers
-5. Correctness issues
-6. Missing integration points / sequencing issues
-7. Simplifications / alternatives
-
-## Rules
-
-- Be specific and actionable
-- Verify existing file paths and anchors before trusting them
-- Do not ask the user direct questions in your output
-- Flag any `MODIFY` path that does not exist
-- Flag any factual claim in `Verified Repo Truths` that lacks exact evidence
-- Flag any negative claim that lacks search evidence
-- Flag any future/proposed language inside `Verified Repo Truths`
-- Flag any place where the plan loses the why, weakens a locked decision, or
-  silently changes a non-goal
-- Do not trust dossier claims blindly
-- Flag unresolved factual conflicts between the plan and dossier
-- Flag ignored material anchors, gotchas, or docs
-- Flag placeholder/template leakage
-- Flag repo-shape mismatches and approximate code patterns
-- Do not recommend adding tests unless the user explicitly wants them
-- Do not recommend compatibility layers unless requested
+Rules:
+- Focus on issues that could cause implementation failure or churn.
+- Do not recommend backwards-compatibility layers unless requested.
+- Do not recommend adding tests unless the user explicitly wants them.

--- a/.codex/skills/plan/SKILL.md
+++ b/.codex/skills/plan/SKILL.md
@@ -1,244 +1,30 @@
 ---
 name: plan
-description: Creates a reconciled implementation plan by combining a structured plan draft with a normalized intent brief and a PRP-style research dossier, then auto-reviews the final plan. Use when planning a new feature or significant change in Codex.
-argument-hint: "[feature description or ticket reference]"
+description: Create a detailed implementation plan for a feature or significant change, grounded in codebase research and external documentation when needed. Use when the user wants a substantial change planned before coding.
 ---
 
 # Plan
 
-Generate a complete plan for feature implementation with thorough research. The
-plan must contain enough context for an AI agent to implement the feature in a
-single pass.
+Create a context-rich implementation plan and stop after the plan is ready.
 
-Codex is the primary planner in this workflow. If you also have a separate
-Claude workflow available, treat it as an optional second-opinion lane rather
-than the source of truth.
+Workflow:
+1. Clarify only genuinely ambiguous requirements.
+2. Inspect the codebase for existing patterns, relevant files, and constraints.
+3. Browse official documentation when the work depends on current external behavior.
+4. Draft the plan using `./plan_base.md` in this skill directory.
+5. Save it to `./tmp/ready-plans/YYYY-MM-DD-description.md`.
+6. Perform one self-review using the standards from `plan-reviewer`.
+7. Apply straightforward improvements silently.
+8. Present the summary, any open questions, and the final plan path.
 
-## Step 1: Mandatory Repo Audit
-
-Do not start drafting until you have verified the current repo shape for the
-feature area.
-
-### Verify These Facts In-Repo
-- Primary entrypoint(s) and integration surfaces relevant to this feature
-- Exact module names and singular/plural usage
-- Validator/controller/service directory layout in the affected area
-- Actual data-model/schema/type source of truth used by this codebase
-- Existing user-facing or operator-facing surface(s) this feature extends
-- Shared type/export hubs if cross-app types are needed
-- Actual validation/build/typecheck workflow used by this repo
-
-### Repo Audit Rules
-- Do not assume any specific stack or layout. Discover the actual routing,
-  validation, schema, frontend, and build patterns used by the current repo.
-- Every existing file path cited in the final plan must have been opened in this
-  session.
-- Mark every path in the final plan as either `existing` or `new`.
-- Never cite a line number unless it was verified in the current checkout.
-- Never let template/example paths leak into the final plan.
-- If the brief or user request conflicts with repo reality, add a `Known
-  Mismatches / Assumptions` section that states the conflict and how the plan
-  resolves it.
-
-## Step 1b: Clarify Requirements (Only If Needed)
-
-If, after the repo audit, the approach is genuinely unclear, ask the user 1-3
-targeted design questions. Otherwise, proceed directly.
-
-## Step 1c: External Research (Only If Needed)
-
-- Library documentation
-- Implementation examples
-- Best practices and common pitfalls
-- Prefer primary documentation when researching external behavior
-
-## Step 2: Draft the Plan, Intent Artifact, and Research Dossier
-
-Produce three artifacts from the same brief:
-
-1. A provisional implementation plan using `./plan_base.md`
-2. A normalized brief / intent artifact that preserves the why, locked
-   decisions, non-goals, and success criteria in a compact downstream-friendly
-   form
-3. A supporting research dossier that behaves like a PRP: anchor-dense,
-   selective, and focused on context transfer
-
-The final output shown to the user is the reconciled plan, not the dossier.
-
-### Step 2a: Draft the Provisional Plan
-
-Use `./plan_base.md` in this skill directory as the template.
-
-### Critical Context to Include
-
-The AI agent only gets the context in the plan plus codebase access. Include:
-- Intent / Why
-- Verified Repo Truths
-- Evidence with exact `file:line-line`
-- Locked Decisions
-- Documentation URLs when needed
-- Code Examples from the codebase
-- Gotchas
-- Patterns to follow
-- Known Mismatches / Assumptions
-- Critical Codebase Anchors
-
-### Plan Guidelines
-
-- Required sections are: Summary, Intent / Why, Source Artifacts, Verified Repo
-  Truths, Locked Decisions, Known Mismatches / Assumptions, Critical Codebase
-  Anchors, Files Being Changed, Reconciliation Notes, Delta Design,
-  Architecture Overview, Key Pseudocode, Tasks, Validation, and Open Questions.
-- `Verified Repo Truths` contains facts only.
-- Every fact needs `Fact`, `Evidence`, and `Implication`.
-- Negative or absence-based claims also need `Search Evidence`.
-- If it is not proven, it is not a fact.
-- Every `MODIFY` path must already exist.
-- Do not leak placeholder/example paths into the final plan.
-- Keep repo facts separate from proposed changes.
-- Mirror current codebase patterns rather than inventing approximate examples.
-- Do not add compatibility layers unless the user explicitly asks.
-- Do not add unit or integration tests by default.
+Plan requirements:
+- Fill in Files Being Changed with a concrete tree.
+- Include Architecture Overview and Key Pseudocode.
+- Reference real codebase files and relevant documentation links.
+- Call out gotchas, constraints, and integration points.
+- Do not include backwards-compatibility shims unless requested.
+- Do not add unit or integration tests to the plan by default.
 - Use `[NEEDS CLARIFICATION]` markers instead of guessing.
 
-### Step 2b: Create a Normalized Brief / Intent Artifact
-
-Save a normalized brief / intent artifact at:
-`./tmp/plan-artifacts/YYYY-MM-DD-description-brief.md`
-
-This is a compact intent capsule for downstream implementation and review.
-Include:
-- Problem / outcome summary
-- Who this matters for
-- Locked decisions already made
-- Non-goals / what must not be optimized away
-- Success criteria
-- Explicit user constraints
-
-The final plan must record this path in `Source Artifacts`.
-
-### Step 2c: Create a Research Dossier
-
-Save a supporting dossier at:
-`./tmp/plan-artifacts/YYYY-MM-DD-description-research-dossier.md`
-
-The dossier should:
-- behave like a PRP-style supporting artifact, not the final plan
-- focus on critical codebase anchors, patterns to reuse, gotchas, external docs,
-  and a suggested implementation shape
-- use exact `file:line-line` references for repo claims
-- include external docs only when they materially reduce risk
-- avoid placeholder text and generic examples
-
-## Step 3: Reconcile the Dossier into the Final Plan
-
-Before saving the user-facing plan, compare the provisional plan against the
-research dossier and reconcile them.
-
-### Reconciliation Goals
-- Import missing anchors from the dossier into the final plan
-- Import missing docs, gotchas, and load-bearing constraints
-- Preserve the brief's why, locked decisions, and non-goals as first-class
-  constraints in the final plan
-- Surface factual conflicts between the draft and dossier
-- Remove duplicated or low-value sections
-- Preserve a clean separation between verified facts, settled decisions, and
-  proposed changes
-
-### Reconciliation Rules
-- The final plan is authoritative
-- The brief / intent artifact is authoritative for why
-- Do not paste the dossier wholesale into the plan
-- If the plan and dossier disagree, re-check the repo before choosing a side
-- If a simplification weakens the brief's intent, surface it rather than hide it
-- Do not import unsupported dossier claims into `Verified Repo Truths`
-- Keep only the highest-value anchors, patterns, docs, and gotchas
-- Add concise `Reconciliation Notes`
-
-### Pre-Save Reality Check
-
-Before saving the plan, verify all of the following:
-- Every `MODIFY` path exists
-- No placeholder/example paths remain
-- Every line anchor was checked in the current checkout
-- Every `Verified Repo Truths` bullet includes `Fact`, `Evidence`, and
-  `Implication`
-- Every negative claim includes `Search Evidence`
-- No future/proposal language appears inside `Verified Repo Truths`
-- Entry points and integration points match the repo audit
-- Code examples match current helper patterns
-- The dossier has been compared against the provisional plan
-- Any plan-vs-dossier conflicts were resolved or surfaced explicitly
-
-## Step 4: Save the Final Plan and Supporting Artifacts
-
-Save the final reconciled plan as:
-`./tmp/ready-plans/YYYY-MM-DD-description.md`
-
-Save the supporting research dossier as:
-`./tmp/plan-artifacts/YYYY-MM-DD-description-research-dossier.md`
-
-Save the normalized brief / intent artifact as:
-`./tmp/plan-artifacts/YYYY-MM-DD-description-brief.md`
-
-Only the reconciled plan belongs in `ready-plans`.
-
-## Step 5: Review and Present
-
-After saving the plan, run the review gates.
-
-1. Run a skeptical review against the standards in `plan-reviewer`.
-2. If you can run a fresh second review context, do it and compare results.
-3. If you are operating alongside a separate Claude workflow, you may use that
-   as the parallel second-opinion lane, but Codex remains the primary planner.
-4. Split findings into:
-   - Auto-fixable
-   - Needs user input
-5. Apply all auto-fixable changes silently.
-6. Do not surface questions until all active review lanes are complete and their
-   findings are merged.
-
-### Present to the User
-
-- Plan Summary: 3-5 bullets
-- Questions for You: only genuine decisions or unresolved ambiguity
-- Plan Link: `./tmp/ready-plans/[filename]`
-- Optional links:
-  - Brief / intent artifact
-  - Research dossier
-- End with: `Want to run another review pass, or is this ready to implement?`
-
-If the user wants changes or another review pass, apply the changes and rerun a
-fresh review.
-
-Do not treat the plan as ready if factual blockers remain unresolved.
-
-## Step 6: Return the Plan — Do Not Implement
-
-Once the user confirms the plan is ready, tell them:
-
-```text
-Plan finalized! To implement, run:
-
-/implement ./tmp/ready-plans/[filename]
-```
-
-Your job ends here. Do not start implementing the plan in the same step.
-
-## Quality Checklist
-
-- [ ] Supporting research dossier created
-- [ ] Supporting brief / intent artifact created
-- [ ] Existing file paths verified in-session
-- [ ] No placeholder/example paths leaked from the template
-- [ ] Plan includes `Intent / Why` and `Source Artifacts`
-- [ ] Verified Repo Truths contains facts only
-- [ ] Every verified fact has exact evidence
-- [ ] Every negative claim has search evidence
-- [ ] High-value anchors/docs/gotchas from the dossier were reconciled into the
-      plan or intentionally dropped
-- [ ] The brief's why, locked decisions, and non-goals survived reconciliation
-- [ ] Validation gates are executable by AI
-- [ ] References existing patterns
-- [ ] Clear implementation path
-- [ ] Error handling documented
+Stop condition:
+- Do not implement the plan in the same step unless the user explicitly changes scope.

--- a/.codex/skills/plan/plan_base.md
+++ b/.codex/skills/plan/plan_base.md
@@ -3,17 +3,16 @@ description: |
 
 ## Purpose
 
-Template optimized for AI agents to implement features with sufficient context
-and self-validation capabilities to achieve working code through iterative
-refinement.
+Template optimized for Codex to implement features with sufficient context and
+self-validation loops.
 
 ## Core Principles
 
 1. Context is king
 2. Validation loops matter
-3. Information density matters
-4. Progressive success beats speculative overreach
-5. Follow repository instructions and CLAUDE guidance
+3. Reuse existing patterns
+4. Start simple, validate, then refine
+5. Follow repository instructions and AGENTS guidance
 
 ---
 
@@ -21,21 +20,11 @@ refinement.
 
 [What needs to be built]
 
-## Summary
+## Why
 
-[3-5 lines summarizing what ships, what areas change, and the overall approach]
-
-## Intent / Why
-
-- [Business value and user impact]
+- [Business or user value]
 - [Integration with existing features]
-- [Problems this solves and for whom]
-- [What must remain true even if implementation details change]
-
-## Source Artifacts
-
-- Brief / intent artifact: [path to the normalized brief snapshot or canonical brief]
-- Research dossier: [path to the supporting dossier]
+- [Problems this solves]
 
 ## What
 
@@ -43,269 +32,95 @@ refinement.
 
 ### Success Criteria
 
-- [ ] [Specific measurable outcomes]
-
-## Verified Repo Truths
-
-Only include facts verified in the current repo state. This section must contain
-existing files only. No proposed files, pseudocode, or speculative statements.
-
-### Data / State
-
-- Fact: [Current-state claim]
-  Evidence: [path:line-line]
-  Implication: [Why this matters for the plan]
-  Search Evidence: [Required only for negative/absence claims]
-
-### Entry Points / Integrations
-
-- Fact: [Current-state claim]
-  Evidence: [path:line-line]
-  Implication: [Why this matters for the plan]
-  Search Evidence: [Required only for negative/absence claims]
-
-### Execution / Async Flow
-
-- Fact: [Current-state claim]
-  Evidence: [path:line-line]
-  Implication: [Why this matters for the plan]
-  Search Evidence: [Required only for negative/absence claims]
-
-### Frontend / UI
-
-- Fact: [Current-state claim]
-  Evidence: [path:line-line]
-  Implication: [Why this matters for the plan]
-  Search Evidence: [Required only for negative/absence claims]
-
-### Shared Types / Exports
-
-- Fact: [Current-state claim]
-  Evidence: [path:line-line]
-  Implication: [Why this matters for the plan]
-  Search Evidence: [Required only for negative/absence claims]
-
-## Locked Decisions
-
-- [Design/product decisions already settled by the brief or user]
-- [Non-goals / guardrails that the implementation must not silently weaken]
-
-## Known Mismatches / Assumptions
-
-- Mismatch: [Repo-vs-brief mismatch, or explicit assumption]
-  Repo Evidence: [path:line-line, plus search evidence if needed]
-  Requirement Evidence: [brief text, user request, or external source]
-  Planning Decision: [How the plan resolves the mismatch]
-- [Write `None` if there are none]
-
-## Critical Codebase Anchors
-
-- Anchor: [existing repo path, subsystem, or flow]
-  Evidence: [path:line-line]
-  Reuse / Watch for: [specific pattern, invariant, or constraint]
+- [ ] [Concrete outcome]
 
 ## All Needed Context
 
 ### Documentation & References
 
-- Repo reference: [existing repo path]
-  Why: [pattern, behavior, or caveat to keep in mind]
-- External doc: [official URL]
-  Section: [specific section if relevant]
-  Why: [what it clarifies]
-  Critical insight: [key constraint or gotcha]
+```yaml
+- url: [official documentation URL]
+  why: [specific section to use]
+
+- file: [path/to/example.ts]
+  why: [pattern or gotcha to follow]
+```
 
 ### Files Being Changed
 
-```
-[Tree of all affected files, each marked with ← NEW, ← MODIFIED, or ← DELETED]
-[Annotate each entry as existing or new when useful for clarity]
+```text
+[Tree of every affected file marked with ← NEW, ← MODIFIED, or ← DELETED]
 ```
 
 ### Known Gotchas & Library Quirks
 
-Write concrete gotchas only. If there are none, write `None`.
-
-- [Concrete repo, library, runtime, or product gotcha and why it matters]
-
-## Reconciliation Notes
-
-- Added from dossier: [anchor, doc, or gotcha imported into the final plan]
-- Conflict resolved: [plan-vs-dossier disagreement and repo-verified resolution]
-- Intentionally dropped: [duplicate or low-value material removed from the final plan]
-
-## Delta Design
-
-### Data / State Changes
-
-Existing:
-- [What exists today]
-
-Change:
-- [What will change]
-
-Why:
-- [Why this shape is appropriate]
-
-Risks:
-- [Key implementation or migration risks]
-
-### Entry Point / Integration Flow
-
-Existing:
-- [What exists today]
-
-Change:
-- [What will change]
-
-Why:
-- [Why this shape is appropriate]
-
-Risks:
-- [Key routing, orchestration, or validation risks]
-
-### Execution / Control Flow
-
-Existing:
-- [What exists today]
-
-Change:
-- [What will change]
-
-Why:
-- [Why this shape is appropriate]
-
-Risks:
-- [Key scheduling / orchestration / concurrency risks]
-
-### User-Facing / Operator-Facing Surface
-
-Existing:
-- [What exists today]
-
-Change:
-- [What will change]
-
-Why:
-- [Why this shape is appropriate]
-
-Risks:
-- [Key UX / state / auth risks]
-
-### External / Operational Surface
-
-Existing:
-- [What exists today]
-
-Change:
-- [What will change]
-
-Why:
-- [Why this shape is appropriate]
-
-Risks:
-- [Key observability / operational risks]
+```text
+- [Critical setup, version issue, or behavior]
+```
 
 ## Implementation Blueprint
 
 ### Architecture Overview
 
-[High-level explanation of the approach]
+[Top-down explanation of the approach]
 
 ### Key Pseudocode
 
-```typescript
-// Pseudocode with critical details only
+```ts
+// Only hot spots and tricky logic
 ```
 
 ### Data Models and Structure
 
-```typescript
-Examples:
- - Data model / schema definitions from the repo's actual source of truth
- - Validation schemas / request contracts from the project's actual validation layer
- - Shared interfaces / types / export hubs used by this codebase
- - API request/response types or other integration contracts
+```ts
+// Shared types, validators, schema, request and response shapes
 ```
 
-### Tasks (in implementation order)
+### Tasks
 
-Task [number]:
-Goal:
-- [What this task unlocks]
-Files:
-- MODIFY [existing repo path]
-- CREATE [new repo path]
-Pattern to copy:
-- [existing repo path]
-Gotchas:
-- [Critical caveat]
-Definition of done:
-- [Observable completion state]
+```yaml
+Task 1:
+MODIFY path/to/file.ts:
+  - specific change
+
+Task 2:
+CREATE path/to/new-file.ts:
+  - specific change
+```
 
 ### Integration Points
 
-- Data / schema source of truth: [actual file or directory discovered during the repo audit]
-- Entry points to extend: [actual route, command, worker, event, or bootstrap entrypoint]
-- Validation layer: [actual library, middleware, or contract pattern used by this repo]
-- Domain / service layer: [actual file or directory pattern used by this codebase]
-- User-facing / operator-facing surface: [actual page, view, command, or workflow]
-- Shared types / export hubs: [actual shared locations if cross-boundary types are needed]
-- External / operational hooks: [actual cron, queue, webhook, env, or admin surface if applicable]
+```yaml
+DATABASE:
+  - schema: path
+  - manual-step: command the user must run
 
-## Validation
+ROUTES:
+  - add to: path
+
+FRONTEND:
+  - api client: path
+  - hook: path
+  - component: path
+```
+
+## Validation Loop
 
 ```bash
 npm run lint
 npm run typecheck
 ```
 
-### Factuality Checks
-
-- `Verified Repo Truths` uses `Fact / Evidence / Implication` for every bullet
-- Every negative claim also includes `Search Evidence`
-- No proposal/future language appears in `Verified Repo Truths`
-- No placeholder/template strings remain in the final plan
-- Every `MODIFY` path exists
-
-### Manual Checks
-
-- Scenario: [Manual scenario]
-  Expected: [Expected user-visible or operational result]
-
-## Open Questions
-
-- [Write `None` if there are none]
-
 ## Final Validation Checklist
 
-- [ ] No linting errors: `npm run lint`
-- [ ] No type errors: `npm run typecheck`
-- [ ] Error cases handled gracefully
-- [ ] Shared types / contracts are exported from the codebase's actual shared hubs if needed
-- [ ] Verified Repo Truths contains only checked facts
-- [ ] Every verified fact includes exact evidence
-- [ ] Every negative claim includes search evidence
-- [ ] No proposal language appears in `Verified Repo Truths`
-- [ ] Every `MODIFY` path exists in the repo
-- [ ] No template/example placeholders remain
-- [ ] High-value anchors/docs/gotchas from the supporting dossier were reconciled into the final plan or intentionally dropped
-- [ ] Any plan-vs-dossier factual conflicts were resolved or surfaced explicitly
-- [ ] Entry points and integration points match the current repo structure discovered during the audit
-- [ ] No unresolved factual blockers remain from review
-
-## Deprecated / Removed Code
-
-- [Code paths to delete or simplify as part of the change]
+- [ ] Lint passes
+- [ ] Typecheck passes
+- [ ] Error cases handled
+- [ ] Shared types exported when needed
 
 ## Anti-Patterns to Avoid
 
-- Don't mix verified repo facts with proposed changes
-- Don't cite unverified file paths or line anchors
-- Don't make negative claims without search evidence
-- Don't let template placeholders survive into the final plan
-- Don't paste the supporting dossier wholesale into the final plan
-- Don't silently choose between conflicting plan and dossier claims without re-checking the repo
-- Don't invent approximate code patterns when the repo already has exact ones
-- Don't create new patterns when existing ones work
-- Don't skip validation because "it should work"
+- Creating new patterns when existing ones work
+- Skipping validation
+- Hardcoding values that belong in config
+- Creating files unnecessarily

--- a/.codex/skills/simple-plan/SKILL.md
+++ b/.codex/skills/simple-plan/SKILL.md
@@ -1,43 +1,20 @@
 ---
 name: simple-plan
-description: Quick gut-check before implementing when the user directly asks you to do something. Investigates, proposes a lightweight plan, and implements only after approval. Use this instead of `plan` when the change is straightforward.
-argument-hint: "[what the user wants done]"
+description: Produce a lightweight implementation plan for a direct user request before coding anything. Use when the change is likely straightforward and the user wants a quick gut-check rather than a full formal plan.
 ---
 
 # Simple Plan
 
-When the user directly asks for a change, investigate first and propose a short
-plan before writing code.
+Give the user a short, concrete plan before implementation.
 
-## Plan Contents
+Workflow:
+1. Investigate the current state enough to understand the change.
+2. Explain the likely root cause or current behavior.
+3. Propose the file-level changes and implementation order.
+4. Include brief advice about risks or better alternatives when useful.
+5. Stop and wait for approval before editing code.
 
-### Current State
-- root cause or current behavior
-- concrete file references
-
-### Proposed Changes
-- what needs to change
-- file references where relevant
-- task list in implementation order
-
-### Advice
-- architectural or implementation guidance when useful
-
-## Process
-
-1. Investigate the codebase first
-2. Present the plan to the user
-3. Only implement after approval
-4. After approval, keep one primary implementation authority by default
-5. Keep the user's why, constraints, and non-goals explicit during implementation
-6. After implementation, run `implementation-reviewer`
-7. Prefer a fresh skeptical second review pass before declaring completion
-8. If you have a separate Claude workflow available, it can be the parallel
-   second-opinion lane, but Codex remains primary on this path
-
-## Notes
-
-- Keep the plan concise but concrete
-- Include file references whenever possible
-- If the task is broad or risky, recommend switching to `plan`
-- Do not implement anything until the user approves
+Rules:
+- Do not implement during the initial plan response.
+- Keep the plan concise, but include concrete file references.
+- If the task turns out to be broad or risky, recommend switching to `plan`.


### PR DESCRIPTION
Mirror of [notetakeai/notetake#1752](https://github.com/notetakeai/notetake/pull/1752). Reverts the recent bloat on `/implement` and `.codex/skills/*` after a 3-run controlled experiment on the same feature plan showed the bloated versions correlated with more edge-case misses and convention violations than the pre-bloat versions.

## Summary
- Reverts `/implement` + `.codex/skills/*` to their pre-bloat state.
- **Keeps `/create-plan` untouched** — validated empirically as a net improvement (produces more Verified Repo Truths and Known Mismatches than the old version on the same plan).
- Two minimal universal additions to `/implement` (not reverts):
  - Phase-ordering note: late-phase tasks have higher skip risk.
  - Spawn step: each phase agent's prompt must re-inject the plan's cross-cutting constraints.

## Changes

| File | Before | After |
|---|---:|---:|
| `.claude/skills/implement/SKILL.md` | 258 | 138 |
| `.claude/agents/implementer.md` | 66 | 54 |
| `.claude/agents/implementation-reviewer.md` | 162 | 137 |
| `.codex/skills/implement/SKILL.md` | 149 | 34 |
| `.codex/skills/plan/SKILL.md` | 244 | 30 |
| `.codex/skills/plan/plan_base.md` | 311 | 126 |
| `.codex/skills/commit/SKILL.md` | 65 | 27 |
| `.codex/skills/implementation-reviewer/SKILL.md` | 127 | 28 |
| `.codex/skills/implementer/SKILL.md` | 59 | 25 |
| `.codex/skills/plan-reviewer/SKILL.md` | 78 | 25 |
| `.codex/skills/simple-plan/SKILL.md` | 43 | 20 |

Net: **−918 lines across 11 files**.

## Evidence
3-run experiment on the same implementation plan:
- Pre-bloat skills + light orchestration: 16/17 plan tasks, 15/17 edge cases, 0 convention violations
- New `.codex` (149-line `/implement`): ~11/17 tasks, ~8/17 edge cases, 2 convention violations
- New `.claude` (258-line `/implement`): ~14/17 tasks, ~10/17 edge cases, 2 convention violations

Skill files had grown 2.5-4.4× in ~6 weeks. The added instructions diluted attention to the plan's Known Gotchas + Known Mismatches sections.

## Test plan
- [ ] Verify `/create-plan` still works (kept unchanged)
- [ ] Verify `/implement` spawns phase agents correctly
- [ ] Spot-check `.codex` skills load in the codex harness