### PR TITLE
fix(mac): wrap Claude spawn in sh -c 'exec' for Bun-native binary

### DIFF
--- a/main/src/services/panels/claude/claudeCodeManager.ts
+++ b/main/src/services/panels/claude/claudeCodeManager.ts
@@ -14,6 +14,7 @@ import { findNodeExecutable } from '../../../utils/nodeFinder';
 import { AbstractCliManager } from '../cli/AbstractCliManager';
 import { withLock } from '../../../utils/mutex';
 import { getAppDirectory } from '../../../utils/appDirectory';
+import { escapeForBash } from '../../../utils/wslUtils';
 
 // Extend global object for MCP configuration storage  
 interface GlobalMcpStorage {
@@ -534,8 +535,22 @@ export class ClaudeCodeManager extends AbstractCliManager {
     });
   }
 
-  // Claude now uses the base class spawnPtyProcess with Node.js fallback
-  // No override needed - the base class handles everything
+  // Claude uses the base class spawnPtyProcess with Node.js fallback. The only
+  // hook we override is wrapSpawnArgs so that on Unix the Bun-compiled Claude
+  // binary (v2.1.113+) launches under `sh -c 'exec …'` — the shell resets fd
+  // and signal state before Bun loads, which avoids Electron main's libuv fds,
+  // V8 inspector sockets, renderer-IPC pipes, and (on macOS) Mach exception
+  // ports leaking into Claude's process. Windows stays on the existing
+  // Node-fallback path in AbstractCliManager.
+  protected wrapSpawnArgs(
+    cmd: string,
+    args: string[],
+    env: { [key: string]: string }
+  ): { cmd: string; args: string[]; env: { [key: string]: string } } {
+    if (process.platform === 'win32') return { cmd, args, env };
+    const line = [cmd, ...args].map(escapeForBash).join(' ');
+    return { cmd: '/bin/sh', args: ['-c', `exec ${line}`], env };
+  }
 
   // Implementation of abstract methods from AbstractCliManager
 

--- a/main/src/services/panels/cli/AbstractCliManager.ts
+++ b/main/src/services/panels/cli/AbstractCliManager.ts
@@ -98,6 +98,20 @@ export abstract class AbstractCliManager extends EventEmitter {
   protected abstract buildCommandArgs(options: CliSpawnOptions): string[];
 
   /**
+   * Optionally rewrite the resolved spawn tuple (command, args, env) immediately
+   * before `spawnPtyProcess` is called. Default is identity. Subclasses override
+   * when the target binary needs a sanitized parent process (e.g. wrapping the
+   * Bun-compiled Claude CLI in `sh -c 'exec …'` to reset fd/signal inheritance).
+   */
+  protected wrapSpawnArgs(
+    cmd: string,
+    args: string[],
+    env: { [key: string]: string }
+  ): { cmd: string; args: string[]; env: { [key: string]: string } } {
+    return { cmd, args, env };
+  }
+
+  /**
    * Get the CLI executable path (custom or from PATH)
    */
   protected abstract getCliExecutablePath(): Promise<string>;
@@ -177,8 +191,12 @@ export abstract class AbstractCliManager extends EventEmitter {
       this.logger?.info(`[${this.getCliToolName()}-command] Working directory: ${worktreePath}`);
       this.logger?.info(`[${this.getCliToolName()}-command] Environment vars: ${Object.keys(cliEnv).join(', ')}`);
 
+      // Allow subclasses to wrap the resolved spawn tuple (e.g. sh -c 'exec …'
+      // on Unix for the Claude Bun-native binary). Default is identity.
+      const { cmd: finalCmd, args: finalArgs, env: finalEnv } = this.wrapSpawnArgs(cliCommand, args, env);
+
       // Spawn the process
-      const ptyProcess = await this.spawnPtyProcess(cliCommand, args, worktreePath, env);
+      const ptyProcess = await this.spawnPtyProcess(finalCmd, finalArgs, worktreePath, finalEnv);
 
       // Create process record
       const cliProcess: CliProcess = {

--- a/main/src/utils/wslUtils.ts
+++ b/main/src/utils/wslUtils.ts
@@ -42,7 +42,7 @@ export async function getWSLHome(distro: string): Promise<string | null> {
  * expansion. Safe on Windows because the escaped string goes inside a bash -c
  * argument passed to wsl.exe — it never touches cmd.exe or PowerShell.
  */
-function escapeForBash(value: string): string {
+export function escapeForBash(value: string): string {
   if (!value) return "''";
   return "'" + value.replace(/'/g, "'\\''") + "'";
 }


### PR DESCRIPTION
## Summary

- Claude Code v2.1.113+ ships a per-platform Bun-compiled binary that crashes on startup when spawned directly from Electron main, because it inherits libuv fds, V8 inspector sockets, renderer-IPC pipes, non-default signal dispositions, and (on macOS) Mach exception ports.
- On Unix we now wrap the resolved Claude invocation in `sh -c 'exec …'` so the shell resets fd and signal state before Bun loads. `exec` is load-bearing — without it the extra `sh` in the tree trips all three `killProcessTree` walks.
- Scope: Claude panel only. Codex, non-Claude CLIs, Windows, and `claude` typed into a Pane terminal are untouched (the terminal case is covered by the follow-up ptyHost migration).

## Changes

- `AbstractCliManager`: new `protected wrapSpawnArgs(cmd, args, env)` hook (default identity), invoked once in `spawnCliProcess` immediately before `spawnPtyProcess`.
- `ClaudeCodeManager`: overrides `wrapSpawnArgs` to produce `sh -c 'exec <escaped cmd> <escaped args>'` on non-win32. Escaping reuses `escapeForBash`.
- `wslUtils.ts`: exports `escapeForBash` so the Claude manager can consume it (mirrors the existing `escapeForBashDoubleQuote` export).

## Regressions considered

- **Windows / Codex / other CLIs**: structurally untouched (override is Claude-only; Windows early-returns identity).
- **kill-process-tree**: `exec` replaces sh in place, so `IPty.pid` points to the claude binary directly. No extra tree level.
- **Claude v1.x Node-based**: `sh -c 'exec <node-wrapper> …'` execs the shebang / npm-bin stub transparently. Low risk but worth a manual sanity check if you still have a v1.x tester.
- **Logs**: the three command-log lines (`AbstractCliManager.ts:174-178, :609-611`, `claudeCodeManager.ts:517`) continue to print the unwrapped form. Cosmetic; the log reflects the requested command, not the implementation detail.

## Test plan

- [ ] macOS + Claude CLI v2.1.113+ → Claude panel launches, streams output, interactive input works.
- [ ] macOS + Claude CLI v1.x (if available) → Claude panel still works, no regression.
- [ ] Linux → Claude panel still works.
- [ ] Windows → Claude panel still works (no shell wrapping applied).
- [ ] `pnpm typecheck` clean.
- [ ] `pnpm lint` clean (no new warnings).

## Follow-up

This is the Phase 0 band-aid from `tmp/ready-plans/2026-04-22-fix-claude-mac-pty-host.md`. Phases 1–4 migrate every `pty.spawn` into a VS Code–style `UtilityProcess`-hosted ptyHost (behind `PANE_USE_PTY_HOST=1`) so this class of spawn-inheritance bug can't recur and `claude` typed into a Pane terminal also works on macOS v2.1.113+. That lands in a separate PR.