### PR TITLE
perf: cut WSL background terminal battery drain

### DIFF
--- a/briefs/wsl-performance-bg-cost.md
+++ b/briefs/wsl-performance-bg-cost.md
@@ -1,0 +1,123 @@
+# Brief: background battery cost on Pane (ARM Windows / WSL)
+
+## Context
+
+User runs roughly 5 Claude panels in the background while working in a foreground panel. Target platform where the pain is most visible: ARM Windows (Snapdragon). Goal is to reduce excess work done by hidden panels. Goal is not to match native Windows Terminal power draw (unreachable for any Electron app), but to close the gap on clear waste.
+
+### Key structural fact
+
+Claude and Codex panels are `panel.type === 'terminal'` with `isCliPanel: true`. They render through `frontend/src/components/panels/TerminalPanel.tsx`, which means every Claude/Codex panel is a full xterm + WebGL instance. Inactive panels stay mounted with `display: none` (`frontend/src/components/SessionView.tsx:976-985`, gated by `shouldKeepAlive = ['terminal', 'browser'].includes(panel.type)`). They do not unmount when the user switches tabs.
+
+The deprecated `frontend/src/components/panels/cli/` folder (`BaseCliPanel.tsx`, `CliPanelFactory.tsx`) is not in the render path. Ignore it.
+
+## Verified good posture (keep as-is)
+
+- WebGL renderer enabled with `onContextLoss` handler (`TerminalPanel.tsx:422-439`).
+- No ligatures addon. No CanvasAddon alongside WebGL.
+- Scrollback is 2,500 (`TerminalPanel.tsx:284`). CLAUDE.md's "50,000 line scrollback" claim is stale for the xterm ring.
+- `cursorBlink: false`, `minimumContrastRatio: 1` (disabled), so no per-tick redraws from those.
+- PTY output coalescing in main (`main/src/services/terminalPanelManager.ts:13-16`): 32 ms batch window, 128 KB size cap, 100 KB high watermark, PTY pause + renderer ACK flow control.
+- node-pty ARM64 Windows prebuild via `@lydell/node-pty-win32-arm64@1.2.0-beta.3` (`pnpm-lock.yaml:1219`). No source rebuild on install.
+- `isActive`-gated resize (`TerminalPanel.tsx:992`).
+
+## Fix candidates (verified waste on hidden panels)
+
+### 1. Detach WebGL addon when panel becomes inactive
+Reattach on activate. Hidden xterm falls back to DOM renderer; DOM paint is skipped entirely for `display: none` subtrees, so the work goes near-zero. WebGL addon has `.dispose()` and can be re-loaded via `loadAddon()`.
+
+Dependency: open verification item below (is the WebGL renderer actually issuing GL draws while hidden, or does it already self-gate).
+
+### 2. Raise PTY batch cadence for hidden panels
+Current `OUTPUT_BATCH_INTERVAL = 32` ms fires for every panel regardless of visibility. Add a hidden-panel cadence (proposed 250 ms) and a renderer-to-main visibility signal so `terminalPanelManager.ts` knows which panels are hidden. Reduces IPC wake-ups on hidden panels roughly 8x. ACK chatter drops proportionally, so no separate fix needed.
+
+### 3. Stop the 30 s SerializeAddon interval on hidden panels
+
+**What the SerializeAddon is.** xterm's `@xterm/addon-serialize` walks the terminal's in-memory buffer (visible rows + scrollback) and emits a string containing text plus ANSI escape sequences. Replaying that string into a fresh xterm reproduces the current visual state: colors, cursor position, text styles. It is distinct from raw PTY scrollback, which preserves the output bytes but not the rendered visual state.
+
+**What Pane does with it.** Pane uses snapshots to restore formatted contents after a PTY has died within the running app, or across a panel unmount/remount in the same session. Call sites in `TerminalPanel.tsx`:
+
+- Every 30 s via `setInterval` while the panel is alive (`TerminalPanel.tsx:549-559`). Ships the serialized string to main via `terminal:saveSnapshot`.
+- Once on unmount / dispose (`TerminalPanel.tsx:1050-1057`).
+
+**Storage.** Snapshots are stored in-memory only in `terminalPanelManager.ts:905-946` (`this.serializedBuffers: Map<panelId, string>`), with an 8 MB per-snapshot cap and 64 MB global cap that prunes oldest on overflow. They do not get persisted to `sessions.db`. They do not survive app restarts.
+
+**What each invocation costs.**
+- Renderer walks the full 2,500-line buffer and builds the serialized string. CPU + allocation, O(buffer size).
+- IPC roundtrip renderer to main with the full string as payload.
+- Main-process updates the in-memory Map; potential prune pass.
+
+**Why it matters for 5 background panels.** The interval fires regardless of `isActive`. Even without disk writes, every 30 s each of 5 hidden panels does a full buffer walk + string build + IPC payload. Steady CPU and GC pressure for no user-visible benefit while the panel is hidden.
+
+**Fix.** The dispose-time call at `TerminalPanel.tsx:1050-1057` already handles clean unmount. The 30 s interval protects against hard tab-switch / panel remount within an active app (losing formatted restore). Replace the interval with:
+- Snapshot once on active-to-inactive transition (covers tab switches and panel hides).
+- Leave the dispose-time snapshot as the backstop.
+
+Worst-case loss on hard crash is the last pre-deactivation visual state, which is acceptable since Pane does not persist snapshots across restarts anyway.
+
+### 4. Scrollback retention policy for archived sessions
+
+**What the DB growth actually is.** `sessions.db` is 238.7 MB on the profiled machine. Breakdown:
+
+- `tool_panels.state` column: 218.6 MB (~95% of the file). 1,731 rows, avg 123 KB each, max 1 MB.
+- Every other table combined: ~0.3 MB. `conversation_messages`, `execution_diffs`, `prompt_markers` are empty.
+
+`tool_panels.state` is a JSON blob per panel that includes `$.customState.scrollbackBuffer`, the raw PTY scrollback (with ANSI escape codes). Written by `saveTerminalState` (distinct from the SerializeAddon path above). No retention policy exists today; archived sessions keep their `state` verbatim forever.
+
+**By archived status on the profiled machine:**
+- Active sessions: 62 sessions, 304 panels, 27.9 MB of state.
+- Archived sessions: 297 sessions, 1,427 panels, 180.6 MB of state.
+- No orphans.
+
+**Retention policy (new feature).**
+
+Rule: on every boot, in the main process, delete the `scrollbackBuffer` field from `tool_panels.state` for any panel whose session is archived and has not been viewed recently.
+
+```sql
+UPDATE tool_panels
+SET state = json_remove(state, '$.customState.scrollbackBuffer')
+WHERE session_id IN (
+  SELECT id FROM sessions
+  WHERE archived = 1
+    AND (last_viewed_at IS NULL OR last_viewed_at < datetime('now', '-21 days'))
+);
+```
+
+Design choices:
+- **Timestamp:** `sessions.last_viewed_at`. No `archived_at` column exists; adding one would need a migration and does not change user-facing semantics meaningfully. `last_viewed_at` captures "haven't touched this archive in X days" which is what the retention is really about.
+- **NULL handling:** treat `last_viewed_at IS NULL` as "very old" and include in the sweep. On the profiled data, this catches 16 archived sessions with no recorded view.
+- **Retention window:** 21 days, hardcoded constant for now. Surface in Settings later if needed.
+- **Timing:** run on boot, deferred ~3 s after the main window is `ready-to-show`. Not on shutdown (shutdown can be skipped by crashes / force-quits / OS power-off; boot is deterministic).
+- **Scope of deletion:** only `$.customState.scrollbackBuffer`. Keep the rest of `state` (cwd, dimensions, shellType, cliReady flags, etc.) so unarchiving still restores a usable panel shell, minus historical output.
+- **Also clear `$.customState.serializedBuffer`** if present, for the same reasons. Verify key exists in the JSON samples before finalizing the `json_remove` path list.
+- **VACUUM:** do not run on boot. SQLite reuses freed pages on subsequent writes, so the file will stop growing even if it does not immediately shrink. A one-shot VACUUM can be exposed as a Settings action later.
+- **Telemetry:** log `[ScrollbackRetention] Cleared N panels across M sessions, freed ~X MB` to the main log. No UI toast.
+- **Placement:** new file `main/src/services/scrollbackRetention.ts`, invoked from `main/src/index.ts` after window ready. Separate module for isolation and testability.
+
+**Expected first-run effect on profiled data:**
+- Panels cleaned: 1,187 across 253 sessions (237 archived-and-old + 16 archived-with-null-last-viewed).
+- Freed: ~148 MB of state payload.
+- Retained: 44 recently-viewed archived sessions keep their scrollback, plus all 62 active sessions.
+
+### 5. Forward WebGL lifecycle events to main-process log
+Renderer-side `console.warn` at `TerminalPanel.tsx:428,437` is the only signal for WebGL load success, initial failure, and context loss. `/mnt/c/Users/khaza/.pane/logs/pane-*.log` contains zero hits because those files are main-process only and renderer console is not forwarded in production. Forward the three events to the main logger. No perf change on its own, but unblocks validation on the ARM box.
+
+## Open verification before sizing fix #1
+
+Does xterm's WebGL renderer issue GL draw calls while the host canvas element is `display: none`? If it self-gates on element visibility (IntersectionObserver or zero-bbox check), hidden-panel GPU work is already zero and fix #1 collapses to a no-op. If it does not self-gate, fix #1 becomes the single largest win for the 5-panel workload.
+
+Resolution: read `node_modules/@xterm/addon-webgl/` render loop. Roughly a 10 minute task. Must complete before any change touching WebGL.
+
+## Out of scope for this brief
+
+- `/mnt/c` vs WSL-home project placement. User choice, Pane cannot force.
+- Main-process polling intervals such as `gitStatusManager.ts`. Separate concern from per-panel background cost.
+- Per-second `terminal:command_executed` log spam from `PanelManager`. Likely benign for battery but worth revisiting later.
+
+## Validation plan (before / after)
+
+On the ARM Windows dev box, with 5 Claude panels streaming tokens in the background and one foreground terminal panel.
+
+- Windows Task Manager per-process: GPU engine %, Power usage category, CPU %.
+- Pane's own logs after fix #5 lands, to confirm WebGL is actually active (not silently fell back to DOM).
+- `sessions.db` size on disk over time, before and after fix #4 (retention sweep).
+- Run sequence: baseline, fix #4 (retention) + fix #3 (snapshot on deactivate), fix #2 (hidden-panel batch cadence), then fix #1 (WebGL detach) if the open verification says it is needed.

--- a/frontend/src/components/SessionView.tsx
+++ b/frontend/src/components/SessionView.tsx
@@ -1097,7 +1097,7 @@ export const SessionView = memo(() => {
                   <div className="pane-terminal-shell-body flex-1 relative min-h-0 pb-1">
                     <PanelContainer
                       panel={defaultTerminalPanel}
-                      isActive={true}
+                      isActive={!immersiveMode}
                       autoFocus={false}
                       isMainRepo={!!activeSession.isMainRepo}
                     />

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -77,8 +77,10 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   const [initError, setInitError] = useState<string | null>(null);
   const [interceptorState, setInterceptorState] = useState<InterceptorState | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [windowFocused, setWindowFocused] = useState(true);
   const interceptorRef = useRef<TerminalInterceptor | null>(null);
   const skipNextInterceptRef = useRef(false); // set by AltGr @ detection
+  const effectiveVisible = isActive && windowFocused;
 
   // Read CLI state from persisted panel state (handles remount case)
   const terminalState = panel.state?.customState as TerminalPanelState | undefined;
@@ -118,17 +120,81 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
   // Keep isActiveRef in sync with isActive prop
   useEffect(() => {
-    isActiveRef.current = isActive;
-  }, [isActive]);
+    isActiveRef.current = effectiveVisible;
+  }, [effectiveVisible]);
+
+  useEffect(() => {
+    let disposed = false;
+    window.electronAPI.window?.isFocused?.()
+      .then((focused) => {
+        if (!disposed) setWindowFocused(focused);
+      })
+      .catch(() => {
+        // Default to focused if the focus query is unavailable.
+      });
+
+    const cleanup = window.electronAPI.events.onWindowFocusChanged((focused) => {
+      setWindowFocused(focused);
+    });
+
+    return () => {
+      disposed = true;
+      cleanup();
+    };
+  }, []);
+
+  const forwardToMainLog = (level: 'info' | 'warn', message: string) => {
+    try {
+      window.electronAPI.invoke('console:log', {
+        level,
+        args: [message],
+        timestamp: new Date().toISOString(),
+        source: 'renderer',
+        toMainLog: true,
+      });
+    } catch {
+      // IPC failure shouldn't break terminal lifecycle work.
+    }
+  };
+
+  const loadWebglRenderer = async (terminal: Terminal, isDisposed: () => boolean) => {
+    if (webglAddonRef.current) return;
+    try {
+      const { WebglAddon: WebglAddonImpl } = await import('@xterm/addon-webgl');
+      if (isDisposed() || webglAddonRef.current) return;
+      const addon = new WebglAddonImpl();
+      addon.onContextLoss(() => {
+        console.warn('[TerminalPanel] WebGL context lost for panel', panel.id, ', falling back to DOM renderer');
+        forwardToMainLog('warn', `[TerminalPanel] WebGL context lost for panel ${panel.id}, falling back to DOM renderer`);
+        try { addon.dispose(); } catch { /* already disposed */ }
+        webglAddonRef.current = null;
+      });
+      terminal.loadAddon(addon);
+      webglAddonRef.current = addon;
+      console.log('[TerminalPanel] WebGL renderer loaded for panel', panel.id);
+      forwardToMainLog('info', `[TerminalPanel] WebGL renderer loaded for panel ${panel.id}`);
+    } catch (e) {
+      console.warn('[TerminalPanel] WebGL renderer failed for panel', panel.id, ', using DOM renderer:', e);
+      forwardToMainLog('warn', `[TerminalPanel] WebGL renderer failed for panel ${panel.id}, using DOM renderer: ${e instanceof Error ? e.message : String(e)}`);
+      webglAddonRef.current = null;
+    }
+  };
+
+  const disposeWebglRenderer = () => {
+    if (!webglAddonRef.current) return;
+    try { webglAddonRef.current.dispose(); } catch { /* ignore */ }
+    webglAddonRef.current = null;
+    forwardToMainLog('info', `[TerminalPanel] WebGL renderer detached for hidden panel ${panel.id}`);
+  };
 
   // Replaces the old 30 s snapshot interval: fire once on active-to-inactive
   // transitions (tab switches / panel hides). The dispose-time snapshot in the
   // terminal init effect stays as a backstop for full unmount.
-  const wasActiveRef = useRef(isActive);
+  const wasActiveRef = useRef(effectiveVisible);
   useEffect(() => {
     const wasActive = wasActiveRef.current;
-    wasActiveRef.current = isActive;
-    if (wasActive && !isActive && serializeAddonRef.current) {
+    wasActiveRef.current = effectiveVisible;
+    if (wasActive && !effectiveVisible && serializeAddonRef.current) {
       try {
         const serialized = serializeAddonRef.current.serialize();
         window.electronAPI.invoke('terminal:saveSnapshot', panel.id, serialized);
@@ -136,7 +202,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
         // xterm buffer in a bad state — not worth surfacing
       }
     }
-  }, [isActive, panel.id]);
+  }, [effectiveVisible, panel.id]);
 
   // Tell main when this panel's visibility changes so PTY output cadence
   // can drop to 250 ms while hidden and snap back to 32 ms when shown.
@@ -146,8 +212,22 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   // current isActive the moment the PTY exists.
   useEffect(() => {
     if (!isInitialized) return;
-    window.electronAPI.invoke('terminal:setVisibility', panel.id, isActive);
-  }, [isActive, panel.id, isInitialized]);
+    window.electronAPI.invoke('terminal:setVisibility', panel.id, effectiveVisible);
+  }, [effectiveVisible, panel.id, isInitialized]);
+
+  useEffect(() => {
+    if (!isInitialized || !xtermRef.current) return;
+    if (!effectiveVisible) {
+      disposeWebglRenderer();
+      return;
+    }
+
+    let disposed = false;
+    void loadWebglRenderer(xtermRef.current, () => disposed);
+    return () => {
+      disposed = true;
+    };
+  }, [effectiveVisible, isInitialized, panel.id]);
 
   // Terminal link handling hook
   const {
@@ -447,45 +527,10 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           console.log('[TerminalPanel] FitAddon fitted');
           terminal.options.theme = getTerminalTheme();
 
-          // Forward WebGL lifecycle events through the existing console:log IPC
-          // so they land in the main-process pane-*.log. The renderer console
-          // calls stay in place for DevTools visibility; this wrapper adds the
-          // toMainLog flag so the main handler knows to route to Logger (needed
-          // in production, where the preload console wrapper is inactive).
-          const forwardToMainLog = (level: 'info' | 'warn', message: string) => {
-            try {
-              window.electronAPI.invoke('console:log', {
-                level,
-                args: [message],
-                timestamp: new Date().toISOString(),
-                source: 'renderer',
-                toMainLog: true,
-              });
-            } catch {
-              // IPC failure shouldn't break terminal init
-            }
-          };
-
-          // Try loading WebGL renderer for GPU-accelerated rendering
-          try {
-            const { WebglAddon: WebglAddonImpl } = await import('@xterm/addon-webgl');
-            if (!disposed) {
-              const addon = new WebglAddonImpl();
-              addon.onContextLoss(() => {
-                console.warn('[TerminalPanel] WebGL context lost for panel', panel.id, ', falling back to DOM renderer');
-                forwardToMainLog('warn', `[TerminalPanel] WebGL context lost for panel ${panel.id}, falling back to DOM renderer`);
-                try { addon.dispose(); } catch { /* already disposed */ }
-                webglAddonRef.current = null;
-              });
-              terminal.loadAddon(addon);
-              webglAddonRef.current = addon;
-              console.log('[TerminalPanel] WebGL renderer loaded for panel', panel.id);
-              forwardToMainLog('info', `[TerminalPanel] WebGL renderer loaded for panel ${panel.id}`);
-            }
-          } catch (e) {
-            console.warn('[TerminalPanel] WebGL renderer failed for panel', panel.id, ', using DOM renderer:', e);
-            forwardToMainLog('warn', `[TerminalPanel] WebGL renderer failed for panel ${panel.id}, using DOM renderer: ${e instanceof Error ? e.message : String(e)}`);
-            webglAddonRef.current = null;
+          // Try loading WebGL renderer for GPU-accelerated rendering. The
+          // visibility effect detaches it while hidden and reloads it on show.
+          if (effectiveVisible) {
+            await loadWebglRenderer(terminal, () => disposed);
           }
 
           // Load WebLinksAddon for clickable URLs
@@ -823,7 +868,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             // Check if this is panel terminal output (has panelId) vs session terminal output (has sessionId)
             if (data && typeof data === 'object' && 'panelId' in data && data.panelId && 'output' in data) {
               const typedData = data as { panelId: string; output: string };
-              if (typedData.panelId === panel.id && terminal && !disposed) {
+              if (typedData.panelId === panel.id && terminal && !disposed && isActiveRef.current) {
                 const outputLength = typedData.output.length;
                 terminal.write(typedData.output, () => {
                   if (disposed) return;
@@ -1141,7 +1186,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
   // Handle visibility changes (resize and full refresh when becoming visible)
   // Include isInitialized so this effect re-runs after terminal initialization completes
   useEffect(() => {
-    if (!isActive || !isInitialized || !fitAddonRef.current || !xtermRef.current) return;
+    if (!effectiveVisible || !isInitialized || !fitAddonRef.current || !xtermRef.current) return;
 
     // Show overlay immediately to mask the terminal.reset()+rewrite flicker
     setIsRefreshing(true);
@@ -1176,7 +1221,7 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
     };
 
     requestAnimationFrame(fitAndRefresh);
-  }, [isActive, panel.id, isInitialized, autoFocus, handleRefreshTerminal]);
+  }, [effectiveVisible, panel.id, isInitialized, autoFocus, handleRefreshTerminal]);
 
   useEffect(() => {
     if (!xtermRef.current) {

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -138,6 +138,13 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
     }
   }, [isActive, panel.id]);
 
+  // Tell main when this panel's visibility changes so PTY output cadence
+  // can drop to 250 ms while hidden and snap back to 32 ms when shown.
+  // Not gated on isInitialized — the main handler is no-op for unknown panel IDs.
+  useEffect(() => {
+    window.electronAPI.invoke('terminal:setVisibility', panel.id, isActive);
+  }, [isActive, panel.id]);
+
   // Terminal link handling hook
   const {
     onMouseMove,
@@ -1059,7 +1066,13 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
     // Not when just switching tabs
     return () => {
       disposed = true;
-      
+
+      // Synchronously push hidden cadence so backgrounded-session unmount
+      // and unmount-during-init both reliably reach main. The inner cleanup
+      // below is deferred via cleanupPromise.then(...) and may never run if
+      // unmount happens before init resolves.
+      window.electronAPI.invoke('terminal:setVisibility', panel.id, false);
+
       // Clean up async initialization
       cleanupPromise.then(cleanupFn => cleanupFn?.());
 

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -121,6 +121,23 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
     isActiveRef.current = isActive;
   }, [isActive]);
 
+  // Replaces the old 30 s snapshot interval: fire once on active-to-inactive
+  // transitions (tab switches / panel hides). The dispose-time snapshot in the
+  // terminal init effect stays as a backstop for full unmount.
+  const wasActiveRef = useRef(isActive);
+  useEffect(() => {
+    const wasActive = wasActiveRef.current;
+    wasActiveRef.current = isActive;
+    if (wasActive && !isActive && serializeAddonRef.current) {
+      try {
+        const serialized = serializeAddonRef.current.serialize();
+        window.electronAPI.invoke('terminal:saveSnapshot', panel.id, serialized);
+      } catch {
+        // xterm buffer in a bad state — not worth surfacing
+      }
+    }
+  }, [isActive, panel.id]);
+
   // Terminal link handling hook
   const {
     onMouseMove,
@@ -419,6 +436,25 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
           console.log('[TerminalPanel] FitAddon fitted');
           terminal.options.theme = getTerminalTheme();
 
+          // Forward WebGL lifecycle events through the existing console:log IPC
+          // so they land in the main-process pane-*.log. The renderer console
+          // calls stay in place for DevTools visibility; this wrapper adds the
+          // toMainLog flag so the main handler knows to route to Logger (needed
+          // in production, where the preload console wrapper is inactive).
+          const forwardToMainLog = (level: 'info' | 'warn', message: string) => {
+            try {
+              window.electronAPI.invoke('console:log', {
+                level,
+                args: [message],
+                timestamp: new Date().toISOString(),
+                source: 'renderer',
+                toMainLog: true,
+              });
+            } catch {
+              // IPC failure shouldn't break terminal init
+            }
+          };
+
           // Try loading WebGL renderer for GPU-accelerated rendering
           try {
             const { WebglAddon: WebglAddonImpl } = await import('@xterm/addon-webgl');
@@ -426,15 +462,18 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
               const addon = new WebglAddonImpl();
               addon.onContextLoss(() => {
                 console.warn('[TerminalPanel] WebGL context lost for panel', panel.id, ', falling back to DOM renderer');
+                forwardToMainLog('warn', `[TerminalPanel] WebGL context lost for panel ${panel.id}, falling back to DOM renderer`);
                 try { addon.dispose(); } catch { /* already disposed */ }
                 webglAddonRef.current = null;
               });
               terminal.loadAddon(addon);
               webglAddonRef.current = addon;
               console.log('[TerminalPanel] WebGL renderer loaded for panel', panel.id);
+              forwardToMainLog('info', `[TerminalPanel] WebGL renderer loaded for panel ${panel.id}`);
             }
           } catch (e) {
             console.warn('[TerminalPanel] WebGL renderer failed for panel', panel.id, ', using DOM renderer:', e);
+            forwardToMainLog('warn', `[TerminalPanel] WebGL renderer failed for panel ${panel.id}, using DOM renderer: ${e instanceof Error ? e.message : String(e)}`);
             webglAddonRef.current = null;
           }
 
@@ -544,19 +583,10 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             }
           };
 
-          // Periodically save serialized snapshot so it's available on app quit
-          // (main process can't call SerializeAddon — only the renderer can)
-          const SNAPSHOT_INTERVAL = 30_000; // 30 seconds
-          const snapshotInterval = setInterval(() => {
-            if (serializeAddonRef.current && terminal && !disposed) {
-              try {
-                const serialized = serializeAddonRef.current.serialize();
-                window.electronAPI.invoke('terminal:saveSnapshot', panel.id, serialized);
-              } catch {
-                // Serialization can fail if terminal is in a bad state — ignore
-              }
-            }
-          }, SNAPSHOT_INTERVAL);
+          // Snapshot persistence: see the active-to-inactive effect below and
+          // the dispose-time snapshot in this effect's cleanup. The previous
+          // 30 s interval was removed to stop hidden panels from doing a full
+          // buffer walk + IPC payload once per half-minute for no visible gain.
 
           // Restore scrollback if we have saved state FOR THIS PANEL
           // When the PTY is alive (initialized === true), always prefer raw scrollback
@@ -1002,7 +1032,6 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
             disposed = true;
             interceptor.dispose();
             interceptorRef.current = null;
-            clearInterval(snapshotInterval);
             flushAck();
             if (ackFlushTimer) clearTimeout(ackFlushTimer);
             resizeObserver.disconnect();

--- a/frontend/src/components/panels/TerminalPanel.tsx
+++ b/frontend/src/components/panels/TerminalPanel.tsx
@@ -140,10 +140,14 @@ export const TerminalPanel: React.FC<TerminalPanelProps> = React.memo(({ panel, 
 
   // Tell main when this panel's visibility changes so PTY output cadence
   // can drop to 250 ms while hidden and snap back to 32 ms when shown.
-  // Not gated on isInitialized — the main handler is no-op for unknown panel IDs.
+  // Gate on isInitialized so panels that mount inactive (hidden background
+  // sessions) actually deliver the signal — main's no-op-on-missing guard
+  // would drop it otherwise. isInitialized in deps ensures re-fire with the
+  // current isActive the moment the PTY exists.
   useEffect(() => {
+    if (!isInitialized) return;
     window.electronAPI.invoke('terminal:setVisibility', panel.id, isActive);
-  }, [isActive, panel.id]);
+  }, [isActive, panel.id, isInitialized]);
 
   // Terminal link handling hook
   const {

--- a/main/src/database/database.ts
+++ b/main/src/database/database.ts
@@ -108,6 +108,12 @@ export class DatabaseService {
     });
   }
 
+  // Raw better-sqlite3 handle for services that need to issue ad-hoc queries
+  // (e.g. retention sweeps) without adding one-off methods to this facade.
+  getDb(): Database.Database {
+    return this.db;
+  }
+
   initialize(): void {
     this.initializeSchema();
     this.runMigrations();

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -37,7 +37,7 @@ import { Logger } from './utils/logger';
 import { ArchiveProgressManager } from './services/archiveProgressManager';
 import { AnalyticsManager } from './services/analyticsManager';
 import { SpotlightManager } from './services/spotlightManager';
-import { ScrollbackRetentionService } from './services/scrollbackRetention';
+import { startupRetentionResult } from './services/database';
 import { resourceMonitorService } from './services/resourceMonitorService';
 import { setAppDirectory, migrateDataDirectory, getAppDirectory } from './utils/appDirectory';
 import { getCurrentWorktreeName } from './utils/worktreeUtils';
@@ -870,7 +870,22 @@ async function initializeServices() {
   // Initialize logger early so it can capture all logs
   logger = new Logger(configManager);
   console.log('[Main] Logger initialized with file logging to ~/.pane/logs');
-  
+
+  // Log the scrollback retention result captured at database module load.
+  // The sweep itself runs before panelManager's constructor caches rows into
+  // RAM (see services/database.ts), so by the time we reach here the DB is
+  // already trimmed and the panel cache is built from the trimmed state.
+  if (startupRetentionResult.error) {
+    logger.error('[ScrollbackRetention] Sweep failed', startupRetentionResult.error);
+  } else if (startupRetentionResult.result && startupRetentionResult.result.panelsCleared > 0) {
+    const r = startupRetentionResult.result;
+    logger.info(
+      `[ScrollbackRetention] Cleared ${r.panelsCleared} panels across ` +
+      `${r.sessionsTouched} sessions, freed ~${(r.bytesFreed / 1_000_000).toFixed(1)} MB`
+    );
+  }
+
+
   // Use the same database path as the original backend
   const dbPath = configManager.getDatabasePath();
   databaseService = new DatabaseService(dbPath);
@@ -1107,25 +1122,7 @@ app.whenReady().then(async () => {
     await versionChecker.checkOnStartup();
   }, 1000); // Small delay to ensure window is fully ready
 
-  // Scrollback retention sweep: clears $.customState.scrollbackBuffer from
-  // tool_panels rows whose session is archived and stale. Deferred so it
-  // doesn't contend with window-ready work. See briefs/wsl-performance-bg-cost.md.
-  setTimeout(() => {
-    try {
-      const retentionService = new ScrollbackRetentionService(databaseService);
-      const result = retentionService.runRetentionSweep();
-      if (result.panelsCleared > 0) {
-        logger.info(
-          `[ScrollbackRetention] Cleared ${result.panelsCleared} panels across ` +
-          `${result.sessionsTouched} sessions, freed ~${(result.bytesFreed / 1_000_000).toFixed(1)} MB`
-        );
-      }
-    } catch (error) {
-      logger.error('[ScrollbackRetention] Sweep failed', error instanceof Error ? error : new Error(String(error)));
-    }
-  }, 3000);
-
-  // Initialize worktree pool — cleanup orphans and seed reserves
+// Initialize worktree pool — cleanup orphans and seed reserves
   setTimeout(async () => {
     try {
       const projects = databaseService.getAllProjects();

--- a/main/src/index.ts
+++ b/main/src/index.ts
@@ -37,6 +37,7 @@ import { Logger } from './utils/logger';
 import { ArchiveProgressManager } from './services/archiveProgressManager';
 import { AnalyticsManager } from './services/analyticsManager';
 import { SpotlightManager } from './services/spotlightManager';
+import { ScrollbackRetentionService } from './services/scrollbackRetention';
 import { resourceMonitorService } from './services/resourceMonitorService';
 import { setAppDirectory, migrateDataDirectory, getAppDirectory } from './utils/appDirectory';
 import { getCurrentWorktreeName } from './utils/worktreeUtils';
@@ -997,25 +998,38 @@ async function initializeServices() {
   // Then set up event listeners that may rely on initialized managers
   setupEventListeners(services, () => mainWindow);
   
-  // Register console logging IPC handler for development
-  if (isDevelopment) {
-    ipcMain.handle('console:log', (event, logData) => {
-      const { level, args, timestamp, source } = logData;
-      const message = args.join(' ');
+  // Console log IPC handler. The preload console wrapper (dev-only) forwards
+  // every renderer console call here for frontend-debug.log capture. Renderer
+  // callers can also invoke this directly and set `toMainLog: true` to also
+  // land the message in the main Logger's pane-*.log — used for surfacing
+  // WebGL lifecycle events so ARM-Windows validation can confirm WebGL loaded
+  // in production builds, where the preload wrapper is inactive.
+  ipcMain.handle('console:log', (_event, logData: { level: string; args: string[]; timestamp: string; source: string; toMainLog?: boolean }) => {
+    const { level, args, timestamp, source, toMainLog } = logData;
+    const message = args.join(' ');
+
+    if (isDevelopment) {
       const logLine = `[${timestamp}] [${source.toUpperCase()} ${level.toUpperCase()}] ${message}\n`;
-      
-      // Write to debug log file
       const debugLogPath = path.join(process.cwd(), 'frontend-debug.log');
       try {
         fs.appendFileSync(debugLogPath, logLine);
       } catch (error) {
         console.error('Failed to write console log to debug file:', error);
       }
-      
-      // Also log to main console with prefix
       console.log(`[Frontend ${level}] ${message}`);
-    });
-  }
+    }
+
+    if (toMainLog) {
+      const forwarded = `[${source}] ${message}`;
+      if (level === 'error') {
+        logger.error(forwarded);
+      } else if (level === 'warn') {
+        logger.warn(forwarded);
+      } else {
+        logger.info(forwarded);
+      }
+    }
+  });
   
   // Start periodic version checking (only if enabled in settings)
   versionChecker.startPeriodicCheck();
@@ -1092,6 +1106,24 @@ app.whenReady().then(async () => {
     console.log('[Main] Performing startup version check...');
     await versionChecker.checkOnStartup();
   }, 1000); // Small delay to ensure window is fully ready
+
+  // Scrollback retention sweep: clears $.customState.scrollbackBuffer from
+  // tool_panels rows whose session is archived and stale. Deferred so it
+  // doesn't contend with window-ready work. See briefs/wsl-performance-bg-cost.md.
+  setTimeout(() => {
+    try {
+      const retentionService = new ScrollbackRetentionService(databaseService);
+      const result = retentionService.runRetentionSweep();
+      if (result.panelsCleared > 0) {
+        logger.info(
+          `[ScrollbackRetention] Cleared ${result.panelsCleared} panels across ` +
+          `${result.sessionsTouched} sessions, freed ~${(result.bytesFreed / 1_000_000).toFixed(1)} MB`
+        );
+      }
+    } catch (error) {
+      logger.error('[ScrollbackRetention] Sweep failed', error instanceof Error ? error : new Error(String(error)));
+    }
+  }, 3000);
 
   // Initialize worktree pool — cleanup orphans and seed reserves
   setTimeout(async () => {

--- a/main/src/ipc/panels.ts
+++ b/main/src/ipc/panels.ts
@@ -500,6 +500,13 @@ export function registerPanelHandlers(ipcMain: IpcMain, services: AppServices) {
     }
   });
 
+  // Renderer tells main when a terminal panel becomes (in)visible so PTY
+  // output cadence can drop to OUTPUT_BATCH_INTERVAL_HIDDEN while hidden.
+  // No-op when the panel's PTY isn't in the map (pre-init / post-destroy).
+  ipcMain.handle('terminal:setVisibility', async (_event, panelId: string, isVisible: boolean) => {
+    terminalPanelManager.setVisibility(panelId, !!isVisible);
+  });
+
   ipcMain.handle('terminal:ack', async (_, panelId: string, bytesConsumed: number) => {
     terminalPanelManager.acknowledgeBytes(panelId, bytesConsumed);
   });

--- a/main/src/services/database.ts
+++ b/main/src/services/database.ts
@@ -1,6 +1,7 @@
 import { DatabaseService } from '../database/database';
 import { join } from 'path';
 import { getAppDirectory } from '../utils/appDirectory';
+import { ScrollbackRetentionService, RetentionSweepResult } from './scrollbackRetention';
 
 // Create and export a singleton instance
 const dbPath = join(getAppDirectory(), 'sessions.db');
@@ -8,3 +9,25 @@ export const databaseService = new DatabaseService(dbPath);
 
 // Initialize the database schema and run migrations
 databaseService.initialize();
+
+// Scrollback retention sweep: runs synchronously at module load, which happens
+// before panelManager's constructor caches any panels into RAM. Deferring this
+// (e.g. via a setTimeout in app.whenReady) would let the in-memory panel cache
+// keep the stale scrollback for the whole first launch even after the DB is
+// trimmed. Result is captured here and logged later once Logger is initialized.
+export const startupRetentionResult: {
+  readonly result: RetentionSweepResult | null;
+  readonly error: Error | null;
+} = (() => {
+  try {
+    return {
+      result: new ScrollbackRetentionService(databaseService).runRetentionSweep(),
+      error: null,
+    };
+  } catch (error) {
+    return {
+      result: null,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+})();

--- a/main/src/services/gitFileWatcher.ts
+++ b/main/src/services/gitFileWatcher.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from 'events';
 import { watch as chokidarWatch, type FSWatcher } from 'chokidar';
 import path from 'path';
 import type { Stats } from 'fs';
+import { spawn, type ChildProcess } from 'child_process';
 import { execSync } from '../utils/commandExecutor';
 import type { CommandRunner } from '../utils/commandRunner';
 import type { PathResolver } from '../utils/pathResolver';
@@ -41,6 +42,7 @@ interface WatchedSession {
   worktreePath: string;
   worktreeWatcher?: FSWatcher;
   gitWatcher?: FSWatcher;
+  wslWatcher?: ChildProcess;
   lastModified: number;
   pendingRefresh: boolean;
 }
@@ -68,6 +70,11 @@ export class GitFileWatcher extends EventEmitter {
     this.setMaxListeners(100);
   }
 
+  setExecutionContext(commandRunner?: CommandRunner, pathResolver?: PathResolver): void {
+    this.commandRunner = commandRunner;
+    this.pathResolver = pathResolver;
+  }
+
   /**
    * Start watching a session's worktree for changes
    */
@@ -76,6 +83,12 @@ export class GitFileWatcher extends EventEmitter {
     this.stopWatching(sessionId);
 
     try {
+      if (this.commandRunner?.wslContext) {
+        if (this.startWSLNativeWatcher(sessionId, worktreePath)) {
+          return;
+        }
+      }
+
       // Convert path for the watcher (needs platform-appropriate path)
       const watchPath = this.pathResolver ? this.pathResolver.toFileSystem(worktreePath) : worktreePath;
 
@@ -178,6 +191,94 @@ export class GitFileWatcher extends EventEmitter {
     }
   }
 
+  private startWSLNativeWatcher(sessionId: string, worktreePath: string): boolean {
+    const distro = this.commandRunner?.wslContext?.distribution;
+    if (!distro || process.platform !== 'win32') return false;
+
+    const script = `
+      set -e
+      cd "$1"
+      if ! command -v inotifywait >/dev/null 2>&1; then
+        echo "__PANE_WSL_MISSING_INOTIFYWAIT__" >&2
+        exit 127
+      fi
+      gitdir="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
+      watch_args=(.)
+      if [ -n "$gitdir" ]; then
+        [ -e "$gitdir/index" ] && watch_args+=("$gitdir/index")
+        [ -e "$gitdir/HEAD" ] && watch_args+=("$gitdir/HEAD")
+      fi
+      exec inotifywait -m -r -q \
+        -e modify,create,delete,move,attrib \
+        --format '%w%f' \
+        --exclude '(^|/)(node_modules|\\.git|\\.next|\\.nuxt|\\.turbo|\\.cache|\\.parcel-cache|\\.venv|venv|__pycache__|\\.svelte-kit)(/|$)' \
+        "\${watch_args[@]}"
+    `;
+
+    const child = spawn('wsl.exe', ['-d', distro, '--', 'bash', '-lc', script, 'pane-wsl-watch', worktreePath], {
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdoutBuffer = '';
+    child.stdout?.setEncoding('utf8');
+    child.stdout?.on('data', (chunk: string) => {
+      stdoutBuffer += chunk;
+      const lines = stdoutBuffer.split('\n');
+      stdoutBuffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (line.trim()) {
+          this.handleFileChange(sessionId, line.trim(), 'change');
+        }
+      }
+    });
+
+    let missingInotify = false;
+    child.stderr?.setEncoding('utf8');
+    child.stderr?.on('data', (chunk: string) => {
+      if (chunk.includes('__PANE_WSL_MISSING_INOTIFYWAIT__')) {
+        missingInotify = true;
+        return;
+      }
+      const message = chunk.trim();
+      if (message) {
+        this.logger?.warn(`[GitFileWatcher] WSL native watcher stderr for ${sessionId}: ${message}`);
+      }
+    });
+
+    child.on('exit', (code, signal) => {
+      const session = this.watchedSessions.get(sessionId);
+      if (session?.wslWatcher === child) {
+        this.watchedSessions.delete(sessionId);
+      }
+      if (missingInotify) {
+        this.logger?.warn(
+          `[GitFileWatcher] WSL native watcher unavailable for ${sessionId}: ` +
+          `install inotify-tools in the distro for live git refresh; falling back to focus/manual refresh only.`
+        );
+      } else if (code !== 0 && signal !== 'SIGTERM') {
+        this.logger?.warn(`[GitFileWatcher] WSL native watcher exited for ${sessionId} with code=${code} signal=${signal ?? 'none'}`);
+      }
+    });
+
+    child.on('error', (error) => {
+      this.logger?.error(`[GitFileWatcher] Failed to start WSL native watcher for ${sessionId}:`, error);
+    });
+
+    this.watchedSessions.set(sessionId, {
+      sessionId,
+      worktreePath,
+      wslWatcher: child,
+      lastModified: Date.now(),
+      pendingRefresh: false,
+    });
+
+    this.logger?.info(
+      `[GitFileWatcher] startWatching(${sessionId}) using WSL native inotify watcher; watchedSessions.size=${this.watchedSessions.size}`
+    );
+    return true;
+  }
+
   /**
    * Stop watching a session's worktree
    */
@@ -188,6 +289,7 @@ export class GitFileWatcher extends EventEmitter {
     // fire-and-forget async close — keeps stopWatching synchronous from callers' perspective
     session.worktreeWatcher?.close().catch(() => {});
     session.gitWatcher?.close().catch(() => {});
+    session.wslWatcher?.kill();
     this.watchedSessions.delete(sessionId);
 
     // Clear any pending refresh timer

--- a/main/src/services/gitStatusManager.ts
+++ b/main/src/services/gitStatusManager.ts
@@ -89,16 +89,15 @@ export class GitStatusManager extends EventEmitter {
     if (previousActive !== sessionId) {
       console.log(`[GitStatus] Active session changed from ${previousActive} to ${sessionId}`);
       
-      // Start watching the active session's files if we have one
-      if (sessionId) {
+      // Start watching only while the window is visible. When Pane is
+      // blurred/minimized, focus refresh is cheaper than keeping recursive
+      // watchers hot, especially for WSL UNC paths.
+      if (sessionId && this.isWindowVisible) {
         this.startWatchingSession(sessionId);
-        
-        // If window is visible, also refresh immediately
-        if (this.isWindowVisible) {
-          this.refreshSessionGitStatus(sessionId, false).catch(error => {
-            console.warn(`[GitStatus] Failed to refresh active session ${sessionId}:`, error);
-          });
-        }
+
+        this.refreshSessionGitStatus(sessionId, false).catch(error => {
+          console.warn(`[GitStatus] Failed to refresh active session ${sessionId}:`, error);
+        });
       }
       
       // Stop watching the previous active session if it exists
@@ -115,6 +114,8 @@ export class GitStatusManager extends EventEmitter {
     try {
       const session = await this.sessionManager.getSession(sessionId);
       if (session?.worktreePath) {
+        const ctx = this.sessionManager.getProjectContext(sessionId);
+        this.fileWatcher.setExecutionContext(ctx?.commandRunner, ctx?.pathResolver);
         this.fileWatcher.startWatching(sessionId, session.worktreePath);
         this.logger?.info(`[GitStatus] Started file watching for session ${sessionId}`);
       }
@@ -169,9 +170,18 @@ export class GitStatusManager extends EventEmitter {
   handleVisibilityChange(isHidden: boolean): void {
     this.isWindowVisible = !isHidden;
     this.gitLogger.logFocusChange(!isHidden);
-    
-    // If window becomes visible and we have an active session, refresh it
-    if (!isHidden && this.activeSessionId) {
+
+    if (isHidden) {
+      if (this.activeSessionId) {
+        this.stopWatchingSession(this.activeSessionId);
+      }
+      return;
+    }
+
+    // If window becomes visible and we have an active session, restart the
+    // watcher and do one authoritative refresh for any changes missed while hidden.
+    if (this.activeSessionId) {
+      this.startWatchingSession(this.activeSessionId);
       this.refreshSessionGitStatus(this.activeSessionId, false).catch(error => {
         console.warn(`[GitStatus] Failed to refresh active session on focus:`, error);
       });

--- a/main/src/services/scrollbackRetention.ts
+++ b/main/src/services/scrollbackRetention.ts
@@ -1,0 +1,55 @@
+import type { DatabaseService } from '../database/database';
+
+const RETENTION_DAYS = 21;
+
+export interface RetentionSweepResult {
+  panelsCleared: number;
+  sessionsTouched: number;
+  bytesFreed: number;
+}
+
+export class ScrollbackRetentionService {
+  constructor(private db: DatabaseService) {}
+
+  runRetentionSweep(): RetentionSweepResult {
+    const sqlite = this.db.getDb();
+
+    const targetSessions = sqlite
+      .prepare(
+        `SELECT id FROM sessions
+         WHERE archived = 1
+           AND (last_viewed_at IS NULL OR last_viewed_at < datetime('now', ?))`
+      )
+      .all(`-${RETENTION_DAYS} days`) as { id: string }[];
+
+    if (targetSessions.length === 0) {
+      return { panelsCleared: 0, sessionsTouched: 0, bytesFreed: 0 };
+    }
+
+    const idsJson = JSON.stringify(targetSessions.map(s => s.id));
+
+    const sizeRow = sqlite
+      .prepare(
+        `SELECT COALESCE(SUM(LENGTH(json_extract(state, '$.customState.scrollbackBuffer'))), 0) AS bytes
+         FROM tool_panels
+         WHERE session_id IN (SELECT value FROM json_each(?))
+           AND json_extract(state, '$.customState.scrollbackBuffer') IS NOT NULL`
+      )
+      .get(idsJson) as { bytes: number };
+
+    const result = sqlite
+      .prepare(
+        `UPDATE tool_panels
+         SET state = json_remove(state, '$.customState.scrollbackBuffer')
+         WHERE session_id IN (SELECT value FROM json_each(?))
+           AND json_extract(state, '$.customState.scrollbackBuffer') IS NOT NULL`
+      )
+      .run(idsJson);
+
+    return {
+      panelsCleared: result.changes,
+      sessionsTouched: targetSessions.length,
+      bytesFreed: sizeRow.bytes,
+    };
+  }
+}

--- a/main/src/services/scrollbackRetention.ts
+++ b/main/src/services/scrollbackRetention.ts
@@ -30,19 +30,28 @@ export class ScrollbackRetentionService {
 
     const sizeRow = sqlite
       .prepare(
-        `SELECT COALESCE(SUM(LENGTH(json_extract(state, '$.customState.scrollbackBuffer'))), 0) AS bytes
+        `SELECT COALESCE(SUM(
+           COALESCE(LENGTH(json_extract(state, '$.customState.scrollbackBuffer')), 0) +
+           COALESCE(LENGTH(json_extract(state, '$.customState.serializedBuffer')), 0)
+         ), 0) AS bytes
          FROM tool_panels
          WHERE session_id IN (SELECT value FROM json_each(?))
-           AND json_extract(state, '$.customState.scrollbackBuffer') IS NOT NULL`
+           AND (
+             json_extract(state, '$.customState.scrollbackBuffer') IS NOT NULL
+             OR json_extract(state, '$.customState.serializedBuffer') IS NOT NULL
+           )`
       )
       .get(idsJson) as { bytes: number };
 
     const result = sqlite
       .prepare(
         `UPDATE tool_panels
-         SET state = json_remove(state, '$.customState.scrollbackBuffer')
+         SET state = json_remove(state, '$.customState.scrollbackBuffer', '$.customState.serializedBuffer')
          WHERE session_id IN (SELECT value FROM json_each(?))
-           AND json_extract(state, '$.customState.scrollbackBuffer') IS NOT NULL`
+           AND (
+             json_extract(state, '$.customState.scrollbackBuffer') IS NOT NULL
+             OR json_extract(state, '$.customState.serializedBuffer') IS NOT NULL
+           )`
       )
       .run(idsJson);
 

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -10,11 +10,13 @@ import type { AnalyticsManager } from './analyticsManager';
 import { getWSLShellSpawn, buildWSLENV, WSLContext } from '../utils/wslUtils';
 import { GIT_ATTRIBUTION_ENV } from '../utils/attribution';
 
-const HIGH_WATERMARK = 100_000; // 100KB — pause PTY when pending exceeds this
+const HIGH_WATERMARK = 100_000; // 100KB — pause PTY when pending exceeds this (visible panels)
+const HIGH_WATERMARK_HIDDEN = 300_000; // 300KB — raised watermark for hidden panels so the slower 250ms cadence doesn't trigger pause/resume churn on verbose builds
 const LOW_WATERMARK = 10_000;   // 10KB — resume PTY when pending drops below this
 const OUTPUT_BATCH_INTERVAL = 32; // ms (~30fps) — wider window reduces TUI flicker
 const OUTPUT_BATCH_INTERVAL_HIDDEN = 250; // ms — background / hidden cadence to cut IPC wake-up cost
 const OUTPUT_BATCH_SIZE = 131072; // 128KB — timer-based flush preferred; size trigger is safety net
+const OUTPUT_BATCH_SIZE_HIDDEN = 80_000; // 80KB — cap per-flush size on hidden panels below HIGH_WATERMARK so a single flush can't trip backpressure; high-throughput jobs degrade to size-driven flushes
 const PAUSE_SAFETY_TIMEOUT = 5_000; // 5s — auto-resume PTY if no acks arrive (prevents permanent stall)
 const MAX_CONCURRENT_SPAWNS = 3;
 const IDLE_THRESHOLD_MS = 5_000; // 5s — mark panel idle after no PTY output
@@ -116,8 +118,10 @@ export class TerminalPanelManager {
       });
     }
 
-    // Apply backpressure if watermark exceeded
-    if (terminal.pendingBytes > HIGH_WATERMARK && !terminal.isPaused) {
+    // Apply backpressure if watermark exceeded. Hidden panels get a higher
+    // watermark to absorb the 250ms cadence without constant pause/resume.
+    const watermark = terminal.isVisible ? HIGH_WATERMARK : HIGH_WATERMARK_HIDDEN;
+    if (terminal.pendingBytes > watermark && !terminal.isPaused) {
       terminal.isPaused = true;
       terminal.pty.pause();
 
@@ -571,7 +575,10 @@ export class TerminalPanelManager {
       // Buffer output for batching instead of sending immediately
       terminal.outputBuffer += filtered;
 
-      if (terminal.outputBuffer.length >= OUTPUT_BATCH_SIZE) {
+      // Hidden panels cap per-flush size below HIGH_WATERMARK so a single
+      // flush on a verbose background build can't alone trip backpressure.
+      const sizeThreshold = terminal.isVisible ? OUTPUT_BATCH_SIZE : OUTPUT_BATCH_SIZE_HIDDEN;
+      if (terminal.outputBuffer.length >= sizeThreshold) {
         // Buffer is large enough — flush immediately
         this.flushOutputBuffer(terminal);
       } else if (!terminal.outputFlushTimer) {

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -37,7 +37,8 @@ interface TerminalProcess {
   // Output batching
   outputBuffer: string;
   outputFlushTimer: ReturnType<typeof setTimeout> | null;
-  // Visibility-driven cadence: true → OUTPUT_BATCH_INTERVAL, false → OUTPUT_BATCH_INTERVAL_HIDDEN
+  // Visibility-driven cadence: true → OUTPUT_BATCH_INTERVAL + renderer writes,
+  // false → OUTPUT_BATCH_INTERVAL_HIDDEN + main-process scrollback only.
   isVisible: boolean;
   // Alternate screen buffer tracking — universal TUI detection signal
   isAlternateScreen: boolean;
@@ -106,6 +107,12 @@ export class TerminalPanelManager {
     const data = terminal.outputBuffer;
     terminal.outputBuffer = '';
 
+    if (!terminal.isVisible) {
+      // Hidden terminals run headless: keep PTY output in main scrollback, but
+      // avoid waking the renderer/xterm/WebGL for every background token.
+      return;
+    }
+
     // Track pending bytes for flow control
     terminal.pendingBytes += data.length;
 
@@ -160,10 +167,25 @@ export class TerminalPanelManager {
     if (!terminal) return;
     const wasVisible = terminal.isVisible;
     terminal.isVisible = isVisible;
-    if (!wasVisible && isVisible) {
-      // hidden → visible: flush any buffered output immediately so the user
-      // sees catch-up content without waiting for the next 250 ms tick.
-      this.flushOutputBuffer(terminal);
+    if (wasVisible === isVisible) return;
+
+    if (!isVisible) {
+      // Once hidden, renderer ACKs stop. Do not leave a visible-mode pause
+      // pending against bytes the renderer may never acknowledge.
+      terminal.outputBuffer = '';
+      terminal.pendingBytes = 0;
+      if (terminal.pauseSafetyTimer) {
+        clearTimeout(terminal.pauseSafetyTimer);
+        terminal.pauseSafetyTimer = null;
+      }
+      if (terminal.isPaused) {
+        terminal.isPaused = false;
+        terminal.pty.resume();
+      }
+    } else {
+      // Hidden output is already present in scrollbackBuffer. Drop any stale
+      // hidden batch so the renderer can refresh exactly once from getState.
+      terminal.outputBuffer = '';
     }
   }
 

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -13,6 +13,7 @@ import { GIT_ATTRIBUTION_ENV } from '../utils/attribution';
 const HIGH_WATERMARK = 100_000; // 100KB — pause PTY when pending exceeds this
 const LOW_WATERMARK = 10_000;   // 10KB — resume PTY when pending drops below this
 const OUTPUT_BATCH_INTERVAL = 32; // ms (~30fps) — wider window reduces TUI flicker
+const OUTPUT_BATCH_INTERVAL_HIDDEN = 250; // ms — background / hidden cadence to cut IPC wake-up cost
 const OUTPUT_BATCH_SIZE = 131072; // 128KB — timer-based flush preferred; size trigger is safety net
 const PAUSE_SAFETY_TIMEOUT = 5_000; // 5s — auto-resume PTY if no acks arrive (prevents permanent stall)
 const MAX_CONCURRENT_SPAWNS = 3;
@@ -34,6 +35,8 @@ interface TerminalProcess {
   // Output batching
   outputBuffer: string;
   outputFlushTimer: ReturnType<typeof setTimeout> | null;
+  // Visibility-driven cadence: true → OUTPUT_BATCH_INTERVAL, false → OUTPUT_BATCH_INTERVAL_HIDDEN
+  isVisible: boolean;
   // Alternate screen buffer tracking — universal TUI detection signal
   isAlternateScreen: boolean;
   activityStatus: 'active' | 'idle';
@@ -145,6 +148,18 @@ export class TerminalPanelManager {
         clearTimeout(terminal.pauseSafetyTimer);
         terminal.pauseSafetyTimer = null;
       }
+    }
+  }
+
+  setVisibility(panelId: string, isVisible: boolean): void {
+    const terminal = this.terminals.get(panelId);
+    if (!terminal) return;
+    const wasVisible = terminal.isVisible;
+    terminal.isVisible = isVisible;
+    if (!wasVisible && isVisible) {
+      // hidden → visible: flush any buffered output immediately so the user
+      // sees catch-up content without waiting for the next 250 ms tick.
+      this.flushOutputBuffer(terminal);
     }
   }
 
@@ -279,6 +294,7 @@ export class TerminalPanelManager {
       pauseSafetyTimer: null,
       outputBuffer: '',
       outputFlushTimer: null,
+      isVisible: true,
       isAlternateScreen: false,
       activityStatus: 'idle',
       idleTimer: null,
@@ -559,10 +575,14 @@ export class TerminalPanelManager {
         // Buffer is large enough — flush immediately
         this.flushOutputBuffer(terminal);
       } else if (!terminal.outputFlushTimer) {
-        // Schedule flush for next frame
+        // Schedule flush for next frame. Hidden panels use a slower cadence
+        // to cut main-process IPC wake-ups; foreground panels keep 32 ms.
+        const interval = terminal.isVisible
+          ? OUTPUT_BATCH_INTERVAL
+          : OUTPUT_BATCH_INTERVAL_HIDDEN;
         terminal.outputFlushTimer = setTimeout(() => {
           this.flushOutputBuffer(terminal);
-        }, OUTPUT_BATCH_INTERVAL);
+        }, interval);
       }
     });
     

--- a/main/src/utils/appDirectory.ts
+++ b/main/src/utils/appDirectory.ts
@@ -5,6 +5,26 @@ import { app } from 'electron';
 
 let customAppDir: string | undefined;
 
+function getCliAppDirectory(): string | undefined {
+  const args = process.argv.slice(2);
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith('--pane-dir=')) {
+      return arg.substring('--pane-dir='.length);
+    }
+    if (arg === '--pane-dir' && i + 1 < args.length) {
+      return args[i + 1];
+    }
+    if (arg.startsWith('--foozol-dir=')) {
+      return arg.substring('--foozol-dir='.length);
+    }
+    if (arg === '--foozol-dir' && i + 1 < args.length) {
+      return args[i + 1];
+    }
+  }
+  return undefined;
+}
+
 /**
  * Sets a custom Pane directory path. This should be called early in the
  * application lifecycle, before any services are initialized.
@@ -49,26 +69,33 @@ export function getAppDirectory(): string {
     return customAppDir;
   }
 
-  // 2. Check environment variable (with legacy FOOZOL_DIR fallback)
+  // 2. Check CLI app-dir flags. This must happen inside getAppDirectory()
+  // because services/database is imported before index.ts can parse argv.
+  const cliDir = getCliAppDirectory();
+  if (cliDir) {
+    return cliDir;
+  }
+
+  // 3. Check environment variable (with legacy FOOZOL_DIR fallback)
   const envDir = process.env.PANE_DIR || process.env.FOOZOL_DIR;
   if (envDir) {
     return envDir;
   }
 
-  // 3. If running as an installed app (from DMG, /Applications, etc), always use ~/.pane
+  // 4. If running as an installed app (from DMG, /Applications, etc), always use ~/.pane
   if (isInstalledApp()) {
     console.log('[Pane] Running as installed app, using ~/.pane');
     return join(homedir(), '.pane');
   }
 
-  // 4. If running inside Pane (detected by bundle identifier) in development, use development directory
+  // 5. If running inside Pane (detected by bundle identifier) in development, use development directory
   // This prevents development Pane from interfering with production Pane
   if (process.env.__CFBundleIdentifier === 'com.dcouple.pane' && !app.isPackaged) {
     console.log('[Pane] Detected running inside Pane development, using ~/.pane_dev for isolation');
     return join(homedir(), '.pane_dev');
   }
 
-  // 5. Default to ~/.pane
+  // 6. Default to ~/.pane
   return join(homedir(), '.pane');
 }
 
@@ -79,7 +106,7 @@ export function getAppDirectory(): string {
 export function migrateDataDirectory(): void {
   // Skip migration if a custom directory is set (via --pane-dir, --foozol-dir, or env vars)
   // to avoid moving ~/.foozol out from under a running app that explicitly configured its path
-  if (customAppDir || process.env.PANE_DIR || process.env.FOOZOL_DIR) {
+  if (customAppDir || getCliAppDirectory() || process.env.PANE_DIR || process.env.FOOZOL_DIR) {
     return;
   }
 


### PR DESCRIPTION
## Problem

Running several background Claude/Codex terminal panels on ARM Windows/WSL creates battery drain even when those panels are not visible. The expensive parts are not only the CLI processes themselves: Pane was still waking the renderer, xterm, WebGL, IPC, and Windows-side WSL filesystem watchers for hidden work.

## Changes

### Hidden terminals run headless

- Hidden terminal panels now keep their PTY processes running but stop streaming live output into renderer/xterm/WebGL.
- Main process still captures raw PTY output into `scrollbackBuffer`, tracks activity, tracks alternate-screen/TUI state, and keeps commands progressing.
- When a terminal becomes visible again, the renderer performs one refresh from `terminal:getState`, then resumes live output.
- Effective visibility now includes panel active state and BrowserWindow focus, so blur/minimize puts active terminals into the hidden/headless path too.

Expected gain: near-zero renderer/xterm/WebGL work for hidden terminals, instead of parsing/rendering every background token.

### WebGL detaches while hidden

- WebGL renderer loads only for effectively visible terminals.
- On hidden transition, the WebGL addon is disposed; on visible transition it is reloaded after the terminal refresh.
- Existing lifecycle logging remains in the main log so ARM Windows validation can confirm WebGL state.

Expected gain: hidden terminal GPU/canvas work drops to zero if xterm WebGL does not fully self-gate on hidden DOM.

### WSL git watching is native-only

- WSL projects no longer use Windows-side chokidar over `\\wsl.localhost` for git status watching.
- For WSL sessions, Pane starts an in-distro `inotifywait` watcher via `wsl.exe`.
- If `inotifywait` is unavailable, Pane logs a warning and falls back to focus/manual refresh rather than using the expensive Windows/WSL filesystem emulation path.
- Watchers are stopped on blur/minimize and restarted with one authoritative refresh on focus.

Expected gain: avoids recursive cross-boundary filesystem watching, which is especially expensive on WSL.

### Existing background-cost fixes retained

- Archived-session scrollback retention trims old `tool_panels.state` payloads on startup.
- Serialized xterm snapshots happen on deactivate/dispose instead of every 30 seconds.
- Hidden terminal batch cadence and backpressure safety remain in place for any transition races.
- CLI app-dir parsing now happens inside `getAppDirectory()` so early database initialization and retention use the correct `--pane-dir`.

## Validation

- `pnpm typecheck`: passes. The environment reports the repo's expected Node >=22.14 warning because this shell is Node 20.19.3.
- `pnpm lint`: passes with 0 errors. Existing warnings remain.
- `git diff --check`: passes.
- WSL watcher shell script was syntax-checked with `bash -n`.

## Manual validation still useful

- On a WSL project with `inotify-tools` installed, switch to a session and confirm logs show the WSL native inotify watcher.
- Modify files from inside the WSL terminal and verify git status refreshes.
- Blur/minimize Pane while a background Claude/Codex panel is streaming; verify the task continues but renderer/GPU activity drops.
- Restore/focus Pane and verify terminal output catches up from scrollback.
