### PR TITLE
[codex] Add explorer QoL basics

### DIFF
--- a/frontend/src/components/panels/editor/FileEditor.tsx
+++ b/frontend/src/components/panels/editor/FileEditor.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import Editor from '@monaco-editor/react';
 import type * as monaco from 'monaco-editor';
-import { ChevronRight, ChevronDown, File, Folder, RefreshCw, Plus, Trash2, FolderPlus, Search, X, Eye, Code, Copy, FolderOpen } from 'lucide-react';
+import { ChevronRight, ChevronDown, File, Folder, RefreshCw, Plus, Trash2, FolderPlus, Search, X, Eye, Code, Copy, FolderOpen, Pencil, Clipboard, ClipboardPaste, CopyPlus } from 'lucide-react';
 import { useTree } from '@headless-tree/react';
 import { asyncDataLoaderFeature, selectionFeature, hotkeysCoreFeature, expandAllFeature } from '@headless-tree/core';
 import type { ItemInstance } from '@headless-tree/core';
@@ -66,13 +66,19 @@ function HeadlessFileTree({
   const [newItemParentPath, setNewItemParentPath] = useState('');
   const newItemInputRef = useRef<HTMLInputElement>(null);
   const [isDragOver, setIsDragOver] = useState(false);
+  const [dragOverPath, setDragOverPath] = useState<string | null>(null);
   const [uploadStatus, setUploadStatus] = useState<string | null>(null);
+  const [selectedItems, setSelectedItems] = useState<string[]>([]);
+  const [clipboard, setClipboard] = useState<{ paths: string[]; mode: 'copy' | 'cut' } | null>(null);
+  const [renamingPath, setRenamingPath] = useState<string | null>(null);
+  const [renamingValue, setRenamingValue] = useState('');
+  const skipRenameCommitRef = useRef(false);
 
   // Context menu state
   const [contextMenu, setContextMenu] = useState<{
     x: number;
     y: number;
-    file: FileItem;
+    file: FileItem | null;
   } | null>(null);
 
   // Platform-adaptive label
@@ -143,9 +149,45 @@ function HeadlessFileTree({
     dataLoader,
     createLoadingItemData: () => ({ name: 'Loading...', path: '', isDirectory: false }),
     features: [asyncDataLoaderFeature, selectionFeature, hotkeysCoreFeature, expandAllFeature],
-    state: { expandedItems },
+    state: { expandedItems, selectedItems },
     setExpandedItems,
+    setSelectedItems,
   });
+
+  const getParentPath = useCallback((filePath: string) => (
+    filePath.includes('/') ? filePath.substring(0, filePath.lastIndexOf('/')) : ''
+  ), []);
+
+  const refreshDirectory = useCallback((dirPath: string) => {
+    filesCacheRef.current.delete(dirPath);
+    tree.getItemInstance(dirPath || ROOT_ID)?.invalidateChildrenIds();
+  }, [tree]);
+
+  const refreshAfterPathsChanged = useCallback((paths: string[]) => {
+    const dirs = new Set<string>(['']);
+    for (const filePath of paths) {
+      dirs.add(getParentPath(filePath));
+      filesCacheRef.current.delete(filePath);
+      const prefix = `${filePath}/`;
+      for (const key of filesCacheRef.current.keys()) {
+        if (key.startsWith(prefix)) filesCacheRef.current.delete(key);
+      }
+    }
+    dirs.forEach(refreshDirectory);
+  }, [getParentPath, refreshDirectory]);
+
+  const getSelectedFilesForAction = useCallback((fallback: FileItem | null) => {
+    if (fallback && !selectedItems.includes(fallback.path)) return [fallback];
+    const selectedFiles = tree.getSelectedItems()
+      .map(item => item.getItemData())
+      .filter((item): item is FileItem => !!item && item.path !== '');
+    return selectedFiles.length > 0 ? selectedFiles : fallback ? [fallback] : [];
+  }, [selectedItems, tree]);
+
+  const getContextTargetDir = useCallback((file: FileItem | null) => {
+    if (!file) return '';
+    return file.isDirectory ? file.path : getParentPath(file.path);
+  }, [getParentPath]);
 
   // Session switch: clear cache and invalidate root
   const prevSessionIdRef = useRef(sessionId);
@@ -194,7 +236,7 @@ function HeadlessFileTree({
 
   // Context menu handlers
   const handleCopyPath = useCallback(async () => {
-    if (!contextMenu) return;
+    if (!contextMenu?.file) return;
     try {
       const result = await window.electronAPI.invoke('file:resolveAbsolutePath', {
         sessionId,
@@ -209,8 +251,18 @@ function HeadlessFileTree({
     setContextMenu(null);
   }, [contextMenu, sessionId]);
 
+  const handleCopyRelativePath = useCallback(async () => {
+    if (!contextMenu?.file) return;
+    try {
+      await navigator.clipboard.writeText(contextMenu.file.path);
+    } catch (err) {
+      console.error('Failed to copy relative path:', err);
+    }
+    setContextMenu(null);
+  }, [contextMenu]);
+
   const handleRevealInFileManager = useCallback(async () => {
-    if (!contextMenu) return;
+    if (!contextMenu?.file) return;
     try {
       await window.electronAPI.invoke('file:showInFolder', {
         sessionId,
@@ -224,48 +276,138 @@ function HeadlessFileTree({
 
   // Delete handler
   const handleDelete = useCallback(async (file: FileItem) => {
-    const confirmMessage = file.isDirectory
-      ? `Are you sure you want to delete the folder "${file.name}" and all its contents?`
-      : `Are you sure you want to delete the file "${file.name}"?`;
+    const files = getSelectedFilesForAction(file);
+    const confirmMessage = files.length > 1
+      ? `Move ${files.length} items to trash?`
+      : files[0]?.isDirectory
+        ? `Move folder "${files[0].name}" and all its contents to trash?`
+        : `Move file "${files[0]?.name}" to trash?`;
     if (!confirm(confirmMessage)) return;
 
     try {
-      const result = await window.electronAPI.invoke('file:delete', {
-        sessionId,
-        filePath: file.path,
-      });
+      for (const target of files) {
+        const result = await window.electronAPI.invoke('file:delete', {
+          sessionId,
+          filePath: target.path,
+          useTrash: true,
+        });
 
-      if (result.success) {
-        const parentPath = file.path.includes('/')
-          ? file.path.substring(0, file.path.lastIndexOf('/'))
-          : '';
-        filesCacheRef.current.delete(parentPath);
-
-        // Purge deleted directory's subtree from cache so stale entries
-        // don't appear in search results
-        if (file.isDirectory) {
-          const prefix = file.path + '/';
-          for (const key of filesCacheRef.current.keys()) {
-            if (key === file.path || key.startsWith(prefix)) {
-              filesCacheRef.current.delete(key);
-            }
-          }
+        if (!result.success) {
+          setError(`Failed to delete: ${result.error}`);
+          return;
         }
+      }
 
-        const parentItemId = parentPath || ROOT_ID;
-        tree.getItemInstance(parentItemId)?.invalidateChildrenIds();
+      refreshAfterPathsChanged(files.map(f => f.path));
+      setSelectedItems(prev => prev.filter(path => !files.some(f => f.path === path || path.startsWith(`${f.path}/`))));
 
-        if (selectedPath === file.path) {
-          onFileSelect(null);
-        }
-      } else {
-        setError(`Failed to delete: ${result.error}`);
+      if (files.some(target => selectedPath === target.path || selectedPath?.startsWith(`${target.path}/`))) {
+        onFileSelect(null);
       }
     } catch (err) {
       console.error('Failed to delete:', err);
       setError(err instanceof Error ? err.message : 'Failed to delete item');
     }
-  }, [sessionId, selectedPath, onFileSelect, tree]);
+  }, [getSelectedFilesForAction, sessionId, refreshAfterPathsChanged, selectedPath, onFileSelect]);
+
+  const startRename = useCallback((file: FileItem) => {
+    skipRenameCommitRef.current = false;
+    setRenamingPath(file.path);
+    setRenamingValue(file.name);
+    setContextMenu(null);
+  }, []);
+
+  const commitRename = useCallback(async (file: FileItem, value: string) => {
+    const newName = value.trim();
+    setRenamingPath(null);
+    if (!newName || newName === file.name) return;
+
+    try {
+      const result = await window.electronAPI.invoke('file:rename', {
+        sessionId,
+        filePath: file.path,
+        newName: newName.trim(),
+      });
+
+      if (!result.success) {
+        setError(`Failed to rename: ${result.error}`);
+        return;
+      }
+
+      const newPath = result.path as string;
+      refreshAfterPathsChanged([file.path, newPath]);
+      setSelectedItems([newPath]);
+      if (selectedPath === file.path) {
+        onFileSelect({ ...file, name: newName.trim(), path: newPath });
+      }
+    } catch (err) {
+      console.error('Failed to rename:', err);
+      setError(err instanceof Error ? err.message : 'Failed to rename item');
+    }
+  }, [sessionId, refreshAfterPathsChanged, selectedPath, onFileSelect]);
+
+  const handleDuplicate = useCallback(async (file: FileItem) => {
+    try {
+      const result = await window.electronAPI.invoke('file:duplicate', {
+        sessionId,
+        filePath: file.path,
+      });
+
+      if (!result.success) {
+        setError(`Failed to duplicate: ${result.error}`);
+        return;
+      }
+
+      refreshAfterPathsChanged([file.path, result.path as string]);
+    } catch (err) {
+      console.error('Failed to duplicate:', err);
+      setError(err instanceof Error ? err.message : 'Failed to duplicate item');
+    }
+  }, [sessionId, refreshAfterPathsChanged]);
+
+  const handleSetClipboard = useCallback((file: FileItem, mode: 'copy' | 'cut') => {
+    const files = getSelectedFilesForAction(file);
+    setClipboard({ paths: files.map(f => f.path), mode });
+    setContextMenu(null);
+  }, [getSelectedFilesForAction]);
+
+  const handlePaste = useCallback(async (targetFile: FileItem | null) => {
+    if (!clipboard || clipboard.paths.length === 0) return;
+    const targetDir = getContextTargetDir(targetFile);
+
+    try {
+      for (const sourcePath of clipboard.paths) {
+        if (clipboard.mode === 'cut' && getParentPath(sourcePath) === targetDir) {
+          continue;
+        }
+        const result = await window.electronAPI.invoke(clipboard.mode === 'cut' ? 'file:move' : 'file:copy', {
+          sessionId,
+          sourcePath,
+          targetDir,
+        });
+
+        if (!result.success) {
+          setError(`Failed to ${clipboard.mode === 'cut' ? 'move' : 'copy'}: ${result.error}`);
+          return;
+        }
+      }
+
+      refreshAfterPathsChanged([...clipboard.paths, targetDir]);
+      if (clipboard.mode === 'cut') setClipboard(null);
+    } catch (err) {
+      console.error('Failed to paste:', err);
+      setError(err instanceof Error ? err.message : 'Failed to paste item');
+    } finally {
+      setContextMenu(null);
+    }
+  }, [clipboard, getContextTargetDir, getParentPath, sessionId, refreshAfterPathsChanged]);
+
+  const openCreateDialog = useCallback((type: 'file' | 'folder', parent: FileItem | null) => {
+    setShowNewItemDialog(type);
+    setNewItemName('');
+    setNewItemParentPath(getContextTargetDir(parent));
+    setContextMenu(null);
+  }, [getContextTargetDir]);
 
   // New file/folder creation with auto-open (the .md bug fix)
   const handleCreateNewItem = useCallback(async () => {
@@ -322,7 +464,7 @@ function HeadlessFileTree({
     }
   }, [tree]);
 
-  const uploadFile = useCallback((file: File): Promise<{ success: boolean; name: string; error?: string }> => {
+  const uploadFile = useCallback((file: File, targetDir = ''): Promise<{ success: boolean; name: string; error?: string; filePath?: string }> => {
     return new Promise((resolve) => {
       const reader = new FileReader();
       reader.onload = async () => {
@@ -332,9 +474,10 @@ function HeadlessFileTree({
             sessionId: sessionIdRef.current,
             fileName: file.name,
             contentBase64: base64,
+            targetDir,
           });
           if (result.success) {
-            resolve({ success: true, name: file.name });
+            resolve({ success: true, name: file.name, filePath: result.filePath });
           } else {
             resolve({ success: false, name: file.name, error: result.error });
           }
@@ -346,6 +489,68 @@ function HeadlessFileTree({
       reader.readAsDataURL(file);
     });
   }, []);
+
+  const handleMoveToDirectory = useCallback(async (files: FileItem[], targetDir: string) => {
+    const movingFiles = files.filter(file => file.path !== targetDir && !targetDir.startsWith(`${file.path}/`));
+    if (movingFiles.length === 0) return;
+
+    try {
+      for (const file of movingFiles) {
+        const result = await window.electronAPI.invoke('file:move', {
+          sessionId,
+          sourcePath: file.path,
+          targetDir,
+        });
+        if (!result.success) {
+          setError(`Failed to move "${file.name}": ${result.error}`);
+          return;
+        }
+      }
+      refreshAfterPathsChanged([...movingFiles.map(f => f.path), targetDir]);
+    } catch (err) {
+      console.error('Failed to move files:', err);
+      setError(err instanceof Error ? err.message : 'Failed to move files');
+    }
+  }, [sessionId, refreshAfterPathsChanged]);
+
+  const handleExternalFileDrop = useCallback(async (files: File[], targetDir = '') => {
+    if (files.length === 0) return;
+
+    const oversized = files.filter(f => f.size > MAX_FILE_SIZE);
+    const validFiles = files.filter(f => f.size <= MAX_FILE_SIZE);
+
+    if (validFiles.length === 0) {
+      if (oversized.length > 0) {
+        setError(`Files too large (max 15MB): ${oversized.map(f => f.name).join(', ')}`);
+      }
+      return;
+    }
+
+    setUploadStatus(`Uploading ${validFiles.length} file${validFiles.length > 1 ? 's' : ''}...`);
+
+    try {
+      const results: { success: boolean; name: string; error?: string; filePath?: string }[] = [];
+      for (const file of validFiles) {
+        results.push(await uploadFile(file, targetDir));
+      }
+      const failed = results.filter(r => !r.success);
+
+      const errors: string[] = [];
+      if (oversized.length > 0) {
+        errors.push(`Too large (max 15MB): ${oversized.map(f => f.name).join(', ')}`);
+      }
+      if (failed.length > 0) {
+        errors.push(`Failed: ${failed.map(r => `${r.name}${r.error ? ` (${r.error})` : ''}`).join(', ')}`);
+      }
+      if (errors.length > 0) setError(errors.join('. '));
+
+      if (results.some(r => r.success)) {
+        refreshDirectory(targetDir);
+      }
+    } finally {
+      setUploadStatus(null);
+    }
+  }, [refreshDirectory, uploadFile]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();
@@ -367,52 +572,36 @@ function HeadlessFileTree({
     e.preventDefault();
     e.stopPropagation();
     setIsDragOver(false);
+    setDragOverPath(null);
     setError(null);
 
     const files = Array.from(e.dataTransfer.files);
-    if (files.length === 0) return;
+    await handleExternalFileDrop(files, '');
+  }, [handleExternalFileDrop]);
 
-    const oversized = files.filter(f => f.size > MAX_FILE_SIZE);
-    const validFiles = files.filter(f => f.size <= MAX_FILE_SIZE);
+  const handleInternalDrop = useCallback(async (e: React.DragEvent, targetDir: string) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOverPath(null);
+    setIsDragOver(false);
 
-    if (validFiles.length === 0) {
-      if (oversized.length > 0) {
-        setError(`Files too large (max 15MB): ${oversized.map(f => f.name).join(', ')}`);
+    const internalPayload = e.dataTransfer.getData('application/x-pane-file-paths');
+    if (internalPayload) {
+      try {
+        const paths = JSON.parse(internalPayload) as string[];
+        const files = paths
+          .map(filePath => tree.getItemInstance(filePath)?.getItemData())
+          .filter((item): item is FileItem => !!item);
+        await handleMoveToDirectory(files, targetDir);
+      } catch (err) {
+        console.error('Failed to parse dropped file paths:', err);
+        setError('Failed to move dropped items');
       }
       return;
     }
 
-    setUploadStatus(`Uploading ${validFiles.length} file${validFiles.length > 1 ? 's' : ''}...`);
-
-    try {
-      // Upload sequentially to avoid race condition when multiple files share the same name
-      const results: { success: boolean; name: string; error?: string }[] = [];
-      for (const file of validFiles) {
-        results.push(await uploadFile(file));
-      }
-      const failed = results.filter(r => !r.success);
-
-      // Combine oversized and failed errors into one message
-      const errors: string[] = [];
-      if (oversized.length > 0) {
-        errors.push(`Too large (max 15MB): ${oversized.map(f => f.name).join(', ')}`);
-      }
-      if (failed.length > 0) {
-        errors.push(`Failed: ${failed.map(r => `${r.name}${r.error ? ` (${r.error})` : ''}`).join(', ')}`);
-      }
-      if (errors.length > 0) {
-        setError(errors.join('. '));
-      }
-
-      const succeeded = results.filter(r => r.success);
-      if (succeeded.length > 0) {
-        filesCacheRef.current.delete('');
-        tree.getItemInstance(ROOT_ID)?.invalidateChildrenIds();
-      }
-    } finally {
-      setUploadStatus(null);
-    }
-  }, [tree, uploadFile]);
+    await handleExternalFileDrop(Array.from(e.dataTransfer.files), targetDir);
+  }, [handleExternalFileDrop, handleMoveToDirectory, tree]);
 
   // Focus input when dialog is shown
   useEffect(() => {
@@ -456,6 +645,10 @@ function HeadlessFileTree({
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const isEditingText = target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || !!target?.isContentEditable;
+      if (isEditingText && e.key !== 'Escape') return;
+
       if ((e.metaKey || e.ctrlKey) && e.key === 'f') {
         e.preventDefault();
         setShowSearch(prev => !prev);
@@ -475,11 +668,37 @@ function HeadlessFileTree({
           searchInputRef.current?.focus();
         }
       }
+      if (e.key === 'F2' && selectedItems.length === 1) {
+        const item = tree.getItemInstance(selectedItems[0])?.getItemData();
+        if (item) {
+          e.preventDefault();
+          startRename(item);
+        }
+      }
+      if ((e.key === 'Delete' || e.key === 'Backspace') && selectedItems.length > 0) {
+        const item = tree.getItemInstance(selectedItems[0])?.getItemData();
+        if (item) {
+          e.preventDefault();
+          handleDelete(item);
+        }
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'c' && selectedItems.length > 0) {
+        e.preventDefault();
+        setClipboard({ paths: selectedItems, mode: 'copy' });
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'x' && selectedItems.length > 0) {
+        e.preventDefault();
+        setClipboard({ paths: selectedItems, mode: 'cut' });
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'v' && clipboard) {
+        e.preventDefault();
+        handlePaste(null);
+      }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [searchQuery, showNewItemDialog, contextMenu]);
+  }, [searchQuery, showNewItemDialog, contextMenu, selectedItems, tree, startRename, handleDelete, clipboard, handlePaste]);
 
   return (
     <div
@@ -631,6 +850,19 @@ function HeadlessFileTree({
       <div
         {...tree.getContainerProps()}
         className={`overflow-auto outline-none ${searchQuery ? 'hidden' : 'flex-1'}`}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setContextMenu({ x: e.clientX, y: e.clientY, file: null });
+        }}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragOverPath('');
+          e.dataTransfer.dropEffect = e.dataTransfer.types.includes('application/x-pane-file-paths') ? 'move' : 'copy';
+        }}
+        onDragLeave={(e) => {
+          if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setDragOverPath(null);
+        }}
+        onDrop={(e) => handleInternalDrop(e, '')}
       >
         {tree.getItems().map((item: ItemInstance<FileItem>) => {
           const data = item.getItemData();
@@ -639,7 +871,8 @@ function HeadlessFileTree({
           const isFolder = data.isDirectory;
           const level = item.getItemMeta().level;
           const isExpanded = item.isExpanded();
-          const isSelected = selectedPath === data.path;
+          const isItemSelected = item.isSelected();
+          const isSelected = selectedPath === data.path || isItemSelected;
 
           return (
             <div
@@ -647,10 +880,40 @@ function HeadlessFileTree({
               {...item.getProps()}
               className={`flex items-center px-2 py-1 hover:bg-surface-hover cursor-pointer group ${
                 isSelected ? 'bg-interactive' : ''
+              } ${
+                dragOverPath === data.path ? 'ring-1 ring-interactive bg-interactive/10' : ''
               }`}
               style={{ paddingLeft: `${level * 16 + 8}px` }}
+              draggable
+              onDragStart={(e) => {
+                const files = getSelectedFilesForAction(data);
+                e.dataTransfer.effectAllowed = 'move';
+                e.dataTransfer.setData('application/x-pane-file-paths', JSON.stringify(files.map(file => file.path)));
+                e.dataTransfer.setData('text/plain', files.map(file => file.path).join('\n'));
+              }}
+              onDragOver={(e) => {
+                if (!isFolder) return;
+                e.preventDefault();
+                e.stopPropagation();
+                setDragOverPath(data.path);
+                e.dataTransfer.dropEffect = e.dataTransfer.types.includes('application/x-pane-file-paths') ? 'move' : 'copy';
+              }}
+              onDragLeave={(e) => {
+                if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setDragOverPath(null);
+              }}
+              onDrop={(e) => {
+                if (!isFolder) return;
+                handleInternalDrop(e, data.path);
+              }}
               onClick={(e) => {
                 e.stopPropagation();
+                if (e.metaKey || e.ctrlKey) {
+                  item.toggleSelect();
+                } else if (e.shiftKey) {
+                  item.selectUpTo(false);
+                } else {
+                  item.select();
+                }
                 if (isFolder) {
                   if (isExpanded) item.collapse();
                   else item.expand();
@@ -673,6 +936,7 @@ function HeadlessFileTree({
               onContextMenu={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
+                if (!item.isSelected()) item.select();
                 setContextMenu({ x: e.clientX, y: e.clientY, file: data });
               }}
             >
@@ -691,7 +955,34 @@ function HeadlessFileTree({
                   <File className="w-4 h-4 mr-2 text-text-tertiary" />
                 </>
               )}
-              <span className="flex-1 text-sm truncate text-text-primary">{data.name}</span>
+              {renamingPath === data.path ? (
+                <input
+                  autoFocus
+                  value={renamingValue}
+                  onChange={(e) => setRenamingValue(e.target.value)}
+                  onClick={(e) => e.stopPropagation()}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      commitRename(data, renamingValue);
+                    } else if (e.key === 'Escape') {
+                      e.preventDefault();
+                      skipRenameCommitRef.current = true;
+                      setRenamingPath(null);
+                    }
+                  }}
+                  onBlur={() => {
+                    if (skipRenameCommitRef.current) {
+                      skipRenameCommitRef.current = false;
+                      return;
+                    }
+                    commitRename(data, renamingValue);
+                  }}
+                  className="flex-1 min-w-0 px-1 py-0.5 bg-surface-primary border border-interactive rounded text-sm text-text-primary focus:outline-none"
+                />
+              ) : (
+                <span className="flex-1 text-sm truncate text-text-primary">{data.name}</span>
+              )}
               {isFolder && (
                 <button
                   onClick={(e) => {
@@ -725,18 +1016,83 @@ function HeadlessFileTree({
         y={contextMenu?.y ?? 0}
         onClose={() => setContextMenu(null)}
       >
-        <PopoverButton onClick={handleCopyPath}>
+        <PopoverButton onClick={() => openCreateDialog('file', contextMenu?.file ?? null)}>
           <span className="flex items-center gap-2">
-            <Copy className="w-4 h-4" />
-            Copy Path
+            <Plus className="w-4 h-4" />
+            New File
           </span>
         </PopoverButton>
-        <PopoverButton onClick={handleRevealInFileManager}>
+        <PopoverButton onClick={() => openCreateDialog('folder', contextMenu?.file ?? null)}>
           <span className="flex items-center gap-2">
-            <FolderOpen className="w-4 h-4" />
-            {revealLabel}
+            <FolderPlus className="w-4 h-4" />
+            New Folder
           </span>
         </PopoverButton>
+        {contextMenu?.file && (
+          <>
+            <div className="my-1 border-t border-border-primary" />
+            <PopoverButton onClick={() => { if (contextMenu.file) startRename(contextMenu.file); }}>
+              <span className="flex items-center gap-2">
+                <Pencil className="w-4 h-4" />
+                Rename
+              </span>
+            </PopoverButton>
+            <PopoverButton onClick={() => { if (contextMenu.file) handleSetClipboard(contextMenu.file, 'copy'); }}>
+              <span className="flex items-center gap-2">
+                <Clipboard className="w-4 h-4" />
+                Copy
+              </span>
+            </PopoverButton>
+            <PopoverButton onClick={() => { if (contextMenu.file) handleSetClipboard(contextMenu.file, 'cut'); }}>
+              <span className="flex items-center gap-2">
+                <Clipboard className="w-4 h-4" />
+                Cut
+              </span>
+            </PopoverButton>
+            <PopoverButton onClick={() => { if (contextMenu.file) { handleDuplicate(contextMenu.file); setContextMenu(null); } }}>
+              <span className="flex items-center gap-2">
+                <CopyPlus className="w-4 h-4" />
+                Duplicate
+              </span>
+            </PopoverButton>
+          </>
+        )}
+        <PopoverButton disabled={!clipboard} onClick={() => handlePaste(contextMenu?.file ?? null)}>
+          <span className="flex items-center gap-2">
+            <ClipboardPaste className="w-4 h-4" />
+            Paste
+          </span>
+        </PopoverButton>
+        {contextMenu?.file && (
+          <>
+            <div className="my-1 border-t border-border-primary" />
+            <PopoverButton onClick={handleCopyRelativePath}>
+              <span className="flex items-center gap-2">
+                <Copy className="w-4 h-4" />
+                Copy Relative Path
+              </span>
+            </PopoverButton>
+            <PopoverButton onClick={handleCopyPath}>
+              <span className="flex items-center gap-2">
+                <Copy className="w-4 h-4" />
+                Copy Absolute Path
+              </span>
+            </PopoverButton>
+            <PopoverButton onClick={handleRevealInFileManager}>
+              <span className="flex items-center gap-2">
+                <FolderOpen className="w-4 h-4" />
+                {revealLabel}
+              </span>
+            </PopoverButton>
+            <div className="my-1 border-t border-border-primary" />
+            <PopoverButton variant="danger" onClick={() => { if (contextMenu.file) { handleDelete(contextMenu.file); setContextMenu(null); } }}>
+              <span className="flex items-center gap-2">
+                <Trash2 className="w-4 h-4" />
+                Move to Trash
+              </span>
+            </PopoverButton>
+          </>
+        )}
       </TerminalPopover>
     </div>
   );

--- a/frontend/src/stores/hotkeyStore.ts
+++ b/frontend/src/stores/hotkeyStore.ts
@@ -136,6 +136,11 @@ function handleKeyDown(e: KeyboardEvent) {
   const def = store.hotkeys.get(hotkeyId);
   if (!def) return;
 
+  // Let native text editing win for shortcuts users expect in focused inputs.
+  // In particular, tab cycling uses mod+a/mod+d, but inputs need mod+a
+  // for select-all and mod+d for normal browser/text-field behavior.
+  if (isInput && (pressed === 'mod+a' || pressed === 'mod+d')) return;
+
   // Skip if typing in input and shortcut doesn't use mod key
   if (isInput && !pressed.includes('mod')) return;
 

--- a/main/src/ipc/file.ts
+++ b/main/src/ipc/file.ts
@@ -38,6 +38,7 @@ interface FileWriteBinaryRequest {
   sessionId: string;
   fileName: string;
   contentBase64: string;
+  targetDir?: string;
 }
 
 interface FilePathRequest {
@@ -53,6 +54,26 @@ interface FileListRequest {
 interface FileDeleteRequest {
   sessionId: string;
   filePath: string;
+  useTrash?: boolean;
+}
+
+interface FileRenameRequest {
+  sessionId: string;
+  filePath: string;
+  newName: string;
+}
+
+interface FileMoveRequest {
+  sessionId: string;
+  sourcePath: string;
+  targetDir: string;
+}
+
+interface FileCopyRequest {
+  sessionId: string;
+  sourcePath: string;
+  targetDir: string;
+  newName?: string;
 }
 
 interface FileItem {
@@ -71,7 +92,65 @@ interface FileSearchRequest {
 }
 
 export function registerFileHandlers(ipcMain: IpcMain, services: AppServices): void {
-  const { sessionManager, databaseService, gitStatusManager, configManager } = services;
+  const { sessionManager, gitStatusManager, configManager } = services;
+
+  async function resolveWorktreePath(sessionId: string, relativePath = ''): Promise<{
+    session: Session;
+    basePath: string;
+    fullPath: string;
+    normalizedPath: string;
+  }> {
+    const session = sessionManager.getSession(sessionId);
+    if (!session) {
+      throw new Error(`Session not found: ${sessionId}`);
+    }
+
+    const ctx = sessionManager.getProjectContext(sessionId);
+    if (!ctx) throw new Error('Project not found for session');
+    const { pathResolver } = ctx;
+
+    const normalizedPath = relativePath ? path.normalize(relativePath) : '';
+    if (normalizedPath.startsWith('..') || path.isAbsolute(normalizedPath)) {
+      throw new Error('Invalid path');
+    }
+
+    const basePath = pathResolver.toFileSystem(session.worktreePath);
+    const fullPath = normalizedPath ? path.join(basePath, normalizedPath) : basePath;
+
+    if (!await pathResolver.isWithin(basePath, fullPath)) {
+      throw new Error('File path is outside worktree');
+    }
+
+    return { session, basePath, fullPath, normalizedPath };
+  }
+
+  function validateSimpleName(name: string): string {
+    const trimmed = name.trim();
+    if (!trimmed || trimmed === '.' || trimmed === '..') {
+      throw new Error('Name is required');
+    }
+    if (trimmed.includes('/') || trimmed.includes('\\') || path.basename(trimmed) !== trimmed) {
+      throw new Error('Name must not contain path separators');
+    }
+    return trimmed;
+  }
+
+  async function uniqueDestinationPath(dirPath: string, requestedName: string): Promise<{ fullPath: string; name: string }> {
+    const parsed = path.parse(requestedName);
+    let candidateName = requestedName;
+    let candidatePath = path.join(dirPath, candidateName);
+    let counter = 1;
+
+    while (await fileExists(candidatePath)) {
+      candidateName = counter === 1
+        ? `${parsed.name} copy${parsed.ext}`
+        : `${parsed.name} copy ${counter}${parsed.ext}`;
+      candidatePath = path.join(dirPath, candidateName);
+      counter++;
+    }
+
+    return { fullPath: candidatePath, name: candidateName };
+  }
 
   // Read file contents from a session's worktree
   ipcMain.handle('file:read', async (_, request: FileReadRequest) => {
@@ -262,6 +341,13 @@ export function registerFileHandlers(ipcMain: IpcMain, services: AppServices): v
       }
 
       const basePath = pathResolver.toFileSystem(session.worktreePath);
+      const targetDir = request.targetDir || '';
+      if (targetDir) {
+        const normalizedTargetDir = path.normalize(targetDir);
+        if (normalizedTargetDir.startsWith('..') || path.isAbsolute(normalizedTargetDir)) {
+          throw new Error('Invalid target directory');
+        }
+      }
 
       // Validate fileName: must be a simple filename, no slashes or ..
       const sanitized = path.basename(request.fileName);
@@ -271,7 +357,13 @@ export function registerFileHandlers(ipcMain: IpcMain, services: AppServices): v
 
       // Resolve full path and verify it's within worktree
       let finalName = sanitized;
-      let fullPath = path.join(basePath, finalName);
+      const targetDirPath = targetDir ? path.join(basePath, targetDir) : basePath;
+      if (!await pathResolver.isWithin(basePath, targetDirPath)) {
+        throw new Error('Target directory is outside worktree');
+      }
+      await fs.mkdir(targetDirPath, { recursive: true });
+
+      let fullPath = path.join(targetDirPath, finalName);
 
       if (!await pathResolver.isWithin(basePath, fullPath)) {
         throw new Error('File path is outside worktree');
@@ -284,7 +376,7 @@ export function registerFileHandlers(ipcMain: IpcMain, services: AppServices): v
         let counter = 1;
         while (await fileExists(fullPath)) {
           finalName = `${base} (${counter})${ext}`;
-          fullPath = path.join(basePath, finalName);
+          fullPath = path.join(targetDirPath, finalName);
           counter++;
         }
       }
@@ -293,7 +385,7 @@ export function registerFileHandlers(ipcMain: IpcMain, services: AppServices): v
       const buffer = Buffer.from(request.contentBase64, 'base64');
       await fs.writeFile(fullPath, buffer);
 
-      return { success: true, finalFileName: finalName };
+      return { success: true, finalFileName: finalName, filePath: targetDir ? path.join(targetDir, finalName) : finalName };
     } catch (error) {
       console.error('Error writing binary file:', error);
       return {
@@ -613,38 +705,26 @@ export function registerFileHandlers(ipcMain: IpcMain, services: AppServices): v
   // Delete a file from a session's worktree
   ipcMain.handle('file:delete', async (_, request: FileDeleteRequest) => {
     try {
-      const session = sessionManager.getSession(request.sessionId);
-      if (!session) {
-        throw new Error(`Session not found: ${request.sessionId}`);
-      }
-
-      const ctx = sessionManager.getProjectContext(request.sessionId);
-      if (!ctx) throw new Error('Project not found for session');
-      const { pathResolver } = ctx;
-
-      // Ensure the file path is relative and safe
-      const normalizedPath = path.normalize(request.filePath);
-      if (normalizedPath.startsWith('..') || path.isAbsolute(normalizedPath)) {
-        throw new Error('Invalid file path');
-      }
-
-      const basePath = pathResolver.toFileSystem(session.worktreePath);
-      const fullPath = path.join(basePath, normalizedPath);
-
-      // Verify the file is within the worktree
-      if (!await pathResolver.isWithin(basePath, fullPath)) {
-        throw new Error('File path is outside worktree');
-      }
+      const { fullPath, normalizedPath } = await resolveWorktreePath(request.sessionId, request.filePath);
 
       // Check if the file exists
       try {
         await fs.access(fullPath);
-      } catch (err) {
+      } catch {
         throw new Error(`File not found: ${normalizedPath}`);
       }
 
       // Check if it's a directory or file
       const stats = await fs.stat(fullPath);
+
+      if (request.useTrash !== false) {
+        try {
+          await shell.trashItem(fullPath);
+          return { success: true };
+        } catch (trashError) {
+          console.warn('Failed to move item to trash, permanently deleting instead:', trashError);
+        }
+      }
 
       if (stats.isDirectory()) {
         // For directories, use rm with recursive option
@@ -657,6 +737,116 @@ export function registerFileHandlers(ipcMain: IpcMain, services: AppServices): v
       return { success: true };
     } catch (error) {
       console.error('Error deleting file:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      };
+    }
+  });
+
+  // Rename a file or folder within a session's worktree
+  ipcMain.handle('file:rename', async (_, request: FileRenameRequest) => {
+    try {
+      const { basePath, fullPath, normalizedPath } = await resolveWorktreePath(request.sessionId, request.filePath);
+      const newName = validateSimpleName(request.newName);
+      const parentDir = path.dirname(fullPath);
+      const newFullPath = path.join(parentDir, newName);
+
+      const relativeToBase = path.relative(basePath, newFullPath);
+      if (relativeToBase.startsWith('..') || path.isAbsolute(relativeToBase)) {
+        throw new Error('Target path is outside worktree');
+      }
+      if (await fileExists(newFullPath)) {
+        throw new Error(`An item named "${newName}" already exists`);
+      }
+
+      await fs.rename(fullPath, newFullPath);
+      const parentRelative = path.dirname(normalizedPath);
+      const newPath = parentRelative === '.' ? newName : path.join(parentRelative, newName);
+      return { success: true, path: newPath };
+    } catch (error) {
+      console.error('Error renaming file:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      };
+    }
+  });
+
+  // Move a file or folder into a target directory within a session's worktree
+  ipcMain.handle('file:move', async (_, request: FileMoveRequest) => {
+    try {
+      const source = await resolveWorktreePath(request.sessionId, request.sourcePath);
+      const target = await resolveWorktreePath(request.sessionId, request.targetDir);
+
+      const sourceName = path.basename(source.fullPath);
+      const targetStats = await fs.stat(target.fullPath);
+      if (!targetStats.isDirectory()) {
+        throw new Error('Target must be a directory');
+      }
+
+      if (source.fullPath === target.fullPath || target.fullPath.startsWith(source.fullPath + path.sep)) {
+        throw new Error('Cannot move a folder into itself');
+      }
+
+      const destinationPath = path.join(target.fullPath, sourceName);
+      if (await fileExists(destinationPath)) {
+        throw new Error(`An item named "${sourceName}" already exists in the target folder`);
+      }
+
+      await fs.rename(source.fullPath, destinationPath);
+      const newPath = request.targetDir ? path.join(request.targetDir, sourceName) : sourceName;
+      return { success: true, path: newPath };
+    } catch (error) {
+      console.error('Error moving file:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      };
+    }
+  });
+
+  // Copy a file or folder into a target directory within a session's worktree
+  ipcMain.handle('file:copy', async (_, request: FileCopyRequest) => {
+    try {
+      const source = await resolveWorktreePath(request.sessionId, request.sourcePath);
+      const target = await resolveWorktreePath(request.sessionId, request.targetDir);
+
+      const targetStats = await fs.stat(target.fullPath);
+      if (!targetStats.isDirectory()) {
+        throw new Error('Target must be a directory');
+      }
+
+      const requestedName = request.newName ? validateSimpleName(request.newName) : path.basename(source.fullPath);
+      const destination = await uniqueDestinationPath(target.fullPath, requestedName);
+      await fs.cp(source.fullPath, destination.fullPath, { recursive: true, errorOnExist: true });
+
+      const newPath = request.targetDir ? path.join(request.targetDir, destination.name) : destination.name;
+      return { success: true, path: newPath };
+    } catch (error) {
+      console.error('Error copying file:', error);
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      };
+    }
+  });
+
+  // Duplicate a file or folder next to itself within a session's worktree
+  ipcMain.handle('file:duplicate', async (_, request: FilePathRequest) => {
+    try {
+      const source = await resolveWorktreePath(request.sessionId, request.filePath);
+      const parentDir = path.dirname(source.fullPath);
+      const requestedName = path.basename(source.fullPath);
+      const destination = await uniqueDestinationPath(parentDir, requestedName);
+
+      await fs.cp(source.fullPath, destination.fullPath, { recursive: true, errorOnExist: true });
+
+      const parentRelative = path.dirname(source.normalizedPath);
+      const newPath = parentRelative === '.' ? destination.name : path.join(parentRelative, destination.name);
+      return { success: true, path: newPath };
+    } catch (error) {
+      console.error('Error duplicating file:', error);
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Unknown error'
@@ -715,7 +905,7 @@ export function registerFileHandlers(ipcMain: IpcMain, services: AppServices): v
       }
 
       // Get list of tracked files (not gitignored) using git
-      let gitTrackedFiles = new Set<string>();
+      const gitTrackedFiles = new Set<string>();
       let isGitRepo = true;
       try {
         // Get list of all tracked files in the repository


### PR DESCRIPTION
## What changed
This adds the missing basic Explorer interactions users expect from a code editor sidebar.

## Highlights
- added a fuller Explorer context menu with create, rename, copy, cut, paste, duplicate, path copy, reveal, and trash actions
- added inline rename in the tree plus keyboard basics like `F2`, `Delete`, `Cmd/Ctrl+C`, `Cmd/Ctrl+X`, and `Cmd/Ctrl+V`
- added drag-and-drop move support for tree items and target-aware external file drops into folders or root
- added main-process file operations for rename, move, copy, duplicate, targeted binary writes, and trash-backed delete with fallback
- prevented the global `Cmd/Ctrl+A` and `Cmd/Ctrl+D` tab-cycling shortcuts from firing while an input is focused, so text fields in Explorer and browser tabs keep native behavior

## Why
The existing Explorer could open and edit files, but it was missing the baseline quality-of-life file management behaviors users expect from VS Code-like Explorer UI.

## Impact
Explorer panels now support routine file management without forcing users into the terminal or external file manager for basic operations.

## Validation
- `pnpm --filter frontend typecheck`
- `pnpm --filter main typecheck`
- pre-commit checks passed in a clean worktree after linking the repo `node_modules` into that temporary checkout
