### PR TITLE
Fix false terminal finished notifications

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -124,7 +124,7 @@ function App() {
   // Global panel activity status listener
   useEffect(() => {
     const unsubscribe = window.electronAPI?.events?.onPanelActivityStatus?.((data) => {
-      usePanelStore.getState().setActivityStatus(data.panelId, data.status);
+      usePanelStore.getState().setActivityStatus(data.panelId, data.status, data.lastActivityAt);
     });
     return () => unsubscribe?.();
   }, []);

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -16,11 +16,11 @@ interface NotificationSettings {
   enabled: boolean;
 }
 
-// Extra delay on top of the 5s PTY idle threshold before firing a "finished"
+// Extra delay on top of the 30s PTY idle threshold before firing a "finished"
 // notification. Guards against false positives from mid-task pauses: network
 // waits, slow tool calls, shells sitting between commands. Total silent time
-// before a notification fires is roughly 5s (dot flip) + 25s = 30s.
-const NOTIFICATION_DEBOUNCE_MS = 25_000;
+// before a notification fires is roughly 30s (dot flip) + 60s = 90s.
+const NOTIFICATION_DEBOUNCE_MS = 60_000;
 
 export function useNotifications() {
   const [settings, setSettings] = useState<NotificationSettings>({
@@ -157,7 +157,7 @@ export function useNotifications() {
     });
   };
 
-  function maybeNotifyPanelIdle(panelId: string) {
+  function maybeNotifyPanelIdle(panelId: string, scheduledLastActivityAt?: string) {
     const currentSettings = settingsRef.current;
     if (!currentSettings.enabled) return;
 
@@ -171,6 +171,16 @@ export function useNotifications() {
     // panel re-activates; without this check we'd ping "finished" for a
     // panel that is actively running again.
     if (panelStoreState.activityStatus[panelId] !== 'idle') return;
+
+    // Re-check that no PTY output arrived after the idle transition that
+    // scheduled this timer. This catches stale timers around rapid quiet/resume
+    // edges without scanning scrollback.
+    if (
+      scheduledLastActivityAt &&
+      panelStoreState.lastActivityAt[panelId] !== scheduledLastActivityAt
+    ) {
+      return;
+    }
 
     let foundSessionId: string | undefined;
     let foundPanel: ToolPanel | undefined;
@@ -228,9 +238,10 @@ export function useNotifications() {
           // Schedule a debounced notification. Clear any stale timer first.
           const existing = pending.get(panelId);
           if (existing) clearTimeout(existing);
+          const scheduledLastActivityAt = state.lastActivityAt[panelId];
           const timer = setTimeout(() => {
             pending.delete(panelId);
-            maybeNotifyPanelIdle(panelId);
+            maybeNotifyPanelIdle(panelId, scheduledLastActivityAt);
           }, NOTIFICATION_DEBOUNCE_MS);
           pending.set(panelId, timer);
         } else if (prevStatus === 'idle' && status === 'active') {

--- a/frontend/src/stores/panelStore.ts
+++ b/frontend/src/stores/panelStore.ts
@@ -9,6 +9,7 @@ export const usePanelStore = create<PanelStore>()(
     panels: {},
     activePanels: {},
     activityStatus: {},
+    lastActivityAt: {},
 
     // Pure synchronous state updates
     setPanels: (sessionId, panels) => {
@@ -48,6 +49,7 @@ export const usePanelStore = create<PanelStore>()(
           delete state.activePanels[sessionId];
         }
         delete state.activityStatus[panelId];
+        delete state.lastActivityAt[panelId];
       });
     },
 
@@ -63,15 +65,19 @@ export const usePanelStore = create<PanelStore>()(
       });
     },
 
-    setActivityStatus: (panelId, status) => {
+    setActivityStatus: (panelId, status, lastActivityAt) => {
       set((state) => {
         state.activityStatus[panelId] = status;
+        if (lastActivityAt) {
+          state.lastActivityAt[panelId] = lastActivityAt;
+        }
       });
     },
 
     clearActivityStatus: (panelId) => {
       set((state) => {
         delete state.activityStatus[panelId];
+        delete state.lastActivityAt[panelId];
       });
     },
 

--- a/frontend/src/types/electron.d.ts
+++ b/frontend/src/types/electron.d.ts
@@ -269,7 +269,7 @@ interface ElectronAPI {
     // Panel events
     onPanelCreated: (callback: (panel: ToolPanel) => void) => () => void;
     onPanelUpdated: (callback: (panel: ToolPanel) => void) => () => void;
-    onPanelActivityStatus: (callback: (data: { panelId: string; sessionId: string; status: 'active' | 'idle' }) => void) => () => void;
+    onPanelActivityStatus: (callback: (data: { panelId: string; sessionId: string; status: 'active' | 'idle'; lastActivityAt?: string }) => void) => () => void;
     onPanelPromptAdded: (callback: (data: { panelId: string; content: string }) => void) => () => void;
     onPanelResponseAdded: (callback: (data: { panelId: string; content: string }) => void) => () => void;
     

--- a/frontend/src/types/panelStore.ts
+++ b/frontend/src/types/panelStore.ts
@@ -5,6 +5,7 @@ export interface PanelStore {
   panels: Record<string, ToolPanel[]>;        // sessionId -> panels
   activePanels: Record<string, string>;       // sessionId -> active panelId
   activityStatus: Record<string, 'active' | 'idle'>; // panelId -> status
+  lastActivityAt: Record<string, string>;     // panelId -> last PTY output timestamp
 
   // Synchronous state update actions
   setPanels: (sessionId: string, panels: ToolPanel[]) => void;
@@ -12,7 +13,7 @@ export interface PanelStore {
   addPanel: (panel: ToolPanel) => void;
   removePanel: (sessionId: string, panelId: string) => void;
   updatePanelState: (panel: ToolPanel) => void;
-  setActivityStatus: (panelId: string, status: 'active' | 'idle') => void;
+  setActivityStatus: (panelId: string, status: 'active' | 'idle', lastActivityAt?: string) => void;
   clearActivityStatus: (panelId: string) => void;
 
   // Getters

--- a/main/src/preload.ts
+++ b/main/src/preload.ts
@@ -546,8 +546,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ipcRenderer.on('panel:updated', wrappedCallback);
       return () => ipcRenderer.removeListener('panel:updated', wrappedCallback);
     },
-    onPanelActivityStatus: (callback: (data: { panelId: string; sessionId: string; status: 'active' | 'idle' }) => void) => {
-      const wrappedCallback = (_event: Electron.IpcRendererEvent, data: { panelId: string; sessionId: string; status: 'active' | 'idle' }) => callback(data);
+    onPanelActivityStatus: (callback: (data: { panelId: string; sessionId: string; status: 'active' | 'idle'; lastActivityAt?: string }) => void) => {
+      const wrappedCallback = (_event: Electron.IpcRendererEvent, data: { panelId: string; sessionId: string; status: 'active' | 'idle'; lastActivityAt?: string }) => callback(data);
       ipcRenderer.on('panel:activityStatus', wrappedCallback);
       return () => ipcRenderer.removeListener('panel:activityStatus', wrappedCallback);
     },

--- a/main/src/services/terminalPanelManager.ts
+++ b/main/src/services/terminalPanelManager.ts
@@ -19,7 +19,7 @@ const OUTPUT_BATCH_SIZE = 131072; // 128KB — timer-based flush preferred; size
 const OUTPUT_BATCH_SIZE_HIDDEN = 80_000; // 80KB — cap per-flush size on hidden panels below HIGH_WATERMARK so a single flush can't trip backpressure; high-throughput jobs degrade to size-driven flushes
 const PAUSE_SAFETY_TIMEOUT = 5_000; // 5s — auto-resume PTY if no acks arrive (prevents permanent stall)
 const MAX_CONCURRENT_SPAWNS = 3;
-const IDLE_THRESHOLD_MS = 5_000; // 5s — mark panel idle after no PTY output
+const IDLE_THRESHOLD_MS = 30_000; // 30s — mark panel idle after no PTY output
 const MAX_SCROLLBACK_BUFFER_SIZE = 500_000; // 500KB of normal shell history
 const MAX_ALTERNATE_SCREEN_BUFFER_SIZE = 100_000; // 100KB of recent TUI redraw state
 
@@ -905,7 +905,8 @@ export class TerminalPanelManager {
       mainWindow.webContents.send('panel:activityStatus', {
         panelId: terminal.panelId,
         sessionId: terminal.sessionId,
-        status: terminal.activityStatus
+        status: terminal.activityStatus,
+        lastActivityAt: terminal.lastActivity.toISOString()
       });
     }
   }


### PR DESCRIPTION
## Summary
- Increase terminal idle threshold to 30s and keep desktop notification quiet window at ~90s
- Carry lastActivityAt through panel activity IPC and store state
- Re-check last activity before firing finished notifications to avoid stale idle timers

## Testing
- pnpm typecheck
- pnpm lint